### PR TITLE
Add ReadRecordLinkNote function to COD10 - Type Helper

### DIFF
--- a/BaseApp/COD10.TXT
+++ b/BaseApp/COD10.TXT
@@ -637,6 +637,21 @@ OBJECT Codeunit 10 Type Helper
     END;
 
     [External]
+    PROCEDURE ReadRecordLinkNote@45(RecordLink@1000 : Record 2000000068) Note : Text;
+    VAR
+      BinReader@1003 : DotNet "'mscorlib'.System.IO.BinaryReader";
+      IStr@1002 : InStream;
+    BEGIN
+      // Read the Note BLOB
+      RecordLink.Note.CREATEINSTREAM(IStr,TEXTENCODING::UTF8);
+      BinReader := BinReader.BinaryReader(IStr);
+      // Peek if stream is empty
+      IF BinReader.BaseStream.Position = BinReader.BaseStream.Length THEN
+        EXIT;
+      Note := BinReader.ReadString;
+    END;
+
+    [External]
     PROCEDURE GetMaxNumberOfParametersInSQLQuery@31() : Integer;
     BEGIN
       EXIT(2100);


### PR DESCRIPTION
This pull request addresses the requested changes from pull request #11. It adds a function to read notes from record links, similar to the already existing function to write notes to record links. This should suffice to achieve the functionality requested.