### PR TITLE
For Issue #28 RegularExpression.Replace methods added to Codeunit 'Type Helper'

### DIFF
--- a/BaseApp/COD10.TXT
+++ b/BaseApp/COD10.TXT
@@ -408,6 +408,29 @@ OBJECT Codeunit 10 Type Helper
     END;
 
     [External]
+    PROCEDURE RegexReplace@55(StringToReplace@1000 : Text;Pattern@1001 : Text;NewValue@1002 : Text) : Text;
+    VAR
+      Regex@1003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Regex";
+      NewString@1004 : Text;
+    BEGIN
+      Regex := Regex.Regex(Pattern);
+      NewString := Regex.Replace(StringToReplace,NewValue);
+      EXIT(NewString);
+    END;
+
+    [External]
+    PROCEDURE RegexReplaceIgnoreCase@52(StringToReplace@1000 : Text;Pattern@1001 : Text;NewValue@1002 : Text) : Text;
+    VAR
+      Regex@1003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Regex";
+      RegexOptions@1005 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.RegexOptions";
+      NewString@1004 : Text;
+    BEGIN
+      Regex := Regex.Regex(Pattern,RegexOptions.IgnoreCase);
+      NewString := Regex.Replace(StringToReplace,NewValue);
+      EXIT(NewString);
+    END;
+
+    [External]
     PROCEDURE IsMatch@6(Input@1000 : Text;RegExExpression@1003 : Text) : Boolean;
     VAR
       Regex@1002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Regex";

--- a/Test/COD132590.TXT
+++ b/Test/COD132590.TXT
@@ -1439,6 +1439,26 @@ OBJECT Codeunit 132590 Type Helper Unit Tests
       Assert.AreEqual(ExpectedTime,DT2TIME(DateTime),'Invalid time');
     END;
 
+    [Test]
+    PROCEDURE TestRegExReplace@54();
+    VAR
+      TypeHelper@1000 : Codeunit 10;
+    BEGIN
+      Assert.AreEqual('My text and the content to replace!', TypeHelper.RegexReplace('The text and the content to replace!', '^The', 'My'), 'RegexReplace failed.');
+      Assert.AreEqual('The text and the content to replace!', TypeHelper.RegexReplace('The text and the content to replace!', '^the', 'My'), 'RegexReplace failed.');
+      Assert.AreEqual('Hxxxx xxxxx!', TypeHelper.RegExReplace('Hallo world!', '[a-z]', 'x'), 'RegexReplace failed.');
+    END;
+
+    [Test]
+    PROCEDURE TestRegExReplaceIgnoreCase@58();
+    VAR
+      TypeHelper@1001 : Codeunit 10;
+    BEGIN
+      Assert.AreEqual('My text and the content to replace!', TypeHelper.RegexReplaceIgnoreCase('The text and the content to replace!', '^The', 'My'), 'RegexReplaceIgnoreCase failed.');
+      Assert.AreEqual('My text and the content to replace!', TypeHelper.RegexReplaceIgnoreCase('The text and the content to replace!', '^the', 'My'), 'RegexReplaceIgnoreCase failed.');
+      Assert.AreEqual('xxxxx xxxxx!', TypeHelper.RegexReplaceIgnoreCase('Hallo world!', '[a-z]', 'x'), 'RegexReplaceIgnoreCase failed.');
+    END;
+
     BEGIN
     {
       // [FEATURE] [Type Helper] [UT]


### PR DESCRIPTION
- RegexReplace(StringToReplace, RegexPattern, ReplaceText)
  This Replace is case sensitive (without RegexOptions)

- RegexReplaceIgnoreCase(StringToReplace, RegexPattern, ReplaceText)
  This Replace ignore the case (with RegexOptions.IgnorCase)