### PR TITLE
SignedXml support

### DIFF
--- a/BaseApp/COD50015.txt
+++ b/BaseApp/COD50015.txt
@@ -1,0 +1,137 @@
+OBJECT Codeunit 50015 Signed Xml Mgt.
+{
+  OBJECT-PROPERTIES
+  {
+    Date=26/01/18;
+    Time=10:49:58;
+    Modified=Yes;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+
+    [External]
+    PROCEDURE CheckXmlStreamSignature@1000000000(XmlStream@1000000000 : InStream;PublicKey@1000000001 : Text) : Boolean;
+    VAR
+      XmlDocument@1000000002 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlDocument";
+    BEGIN
+      XmlDocument := XmlDocument.XmlDocument();
+      XmlDocument.Load(XmlStream);
+      EXIT(CheckXmlSignature(XmlDocument, PublicKey));
+    END;
+
+    [External]
+    PROCEDURE CheckXmlTextSignature@1000000001(XmlText@1000000000 : Text;PublicKey@1000000001 : Text) : Boolean;
+    VAR
+      XmlDocument@1000000002 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlDocument";
+    BEGIN
+      XmlDocument := XmlDocument.XmlDocument();
+      XmlDocument.LoadXml(XmlText);
+      EXIT(CheckXmlSignature(XmlDocument, PublicKey));
+    END;
+
+    LOCAL PROCEDURE CheckXmlSignature@1000000002(XmlDocument@1000000004 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlDocument";PublicKey@1000000005 : Text) : Boolean;
+    VAR
+      PublicKeyData@1000000000 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Object";
+      Convert@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Convert";
+      RSAKey@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Security.Cryptography.RSACryptoServiceProvider";
+      SignedXml@1000000003 : DotNet "'System.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.System.Security.Cryptography.Xml.SignedXml";
+      SignatureNode@1000000007 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlNode";
+      XmlNamespaceManager@1000000006 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlNamespaceManager";
+    BEGIN
+      //create xml namespace manager
+      XmlNamespaceManager := XmlNamespaceManager.XmlNamespaceManager(XmlDocument.NameTable);
+      XmlNamespaceManager.AddNamespace('xmlsig', 'http://www.w3.org/2000/09/xmldsig#');
+
+      //try to find signature
+      SignatureNode := XmlDocument.FirstChild.SelectSingleNode('xmlsig:Signature', XmlNamespaceManager);
+      IF (ISNULL(SignatureNode)) THEN
+        EXIT(FALSE);
+
+      //Import key
+      PublicKeyData := Convert.FromBase64String(PublicKey);
+      RSAKey := RSAKey.RSACryptoServiceProvider();
+      RSAKey.ImportCspBlob(PublicKeyData);
+
+      // Create a new SignedXml object and pass it
+      // the XML document class.
+      SignedXml := SignedXml.SignedXml(XmlDocument);
+
+      // Load the first <signature> node.
+      SignedXml.LoadXml(SignatureNode);
+
+      // Check the signature and return the result.
+      EXIT(SignedXml.CheckSignature(RSAKey));
+    END;
+
+    [External]
+    PROCEDURE SignXmlText@1000000012(XmlText@1000000000 : Text;PrivateKey@1000000001 : Text) : Text;
+    VAR
+      XmlDocument@1000000002 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlDocument";
+      StringWiter@1000000003 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.IO.StringWriter";
+      XmlWriter@1000000004 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlTextWriter";
+    BEGIN
+      XmlDocument := XmlDocument.XmlDocument();
+      XmlDocument.LoadXml(XmlText);
+      SignXmlDocument(XmlDocument, PrivateKey);
+
+      StringWiter := StringWiter.StringWriter();
+      XmlWriter := XmlWriter.XmlTextWriter(StringWiter);
+      XmlDocument.WriteTo(XmlWriter);
+
+      EXIT(StringWiter.ToString());
+    END;
+
+    LOCAL PROCEDURE SignXmlDocument@1000000013(XmlDocument@1000000001 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlDocument";PrivateKey@1000000000 : Text);
+    VAR
+      Convert@1000000004 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Convert";
+      RSAKey@1000000003 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Security.Cryptography.RSACryptoServiceProvider";
+      SignedXml@1000000002 : DotNet "'System.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.System.Security.Cryptography.Xml.SignedXml";
+      DocReference@1000000005 : DotNet "'System.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.System.Security.Cryptography.Xml.Reference";
+      Env@1000000006 : DotNet "'System.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.System.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform";
+      xmlSignature@1000000007 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlElement";
+    BEGIN
+      //import key
+      RSAKey := RSAKey.RSACryptoServiceProvider();
+      RSAKey.ImportCspBlob(Convert.FromBase64String(PrivateKey));
+
+      //create signed document
+      SignedXml := SignedXml.SignedXml(XmlDocument);
+      SignedXml.SigningKey := RSAKey;
+
+      // Add the key to the SignedXml document.
+      SignedXml.SigningKey := RSAKey;
+
+      // Create a reference to be signed.
+      DocReference := DocReference.Reference();
+      DocReference.Uri := '';
+
+      // Add an enveloped transformation to the reference.
+      Env := Env.XmlDsigEnvelopedSignatureTransform();
+      DocReference.AddTransform(Env);
+
+      // Add the reference to the SignedXml object.
+      SignedXml.AddReference(DocReference);
+
+      // Compute the signature.
+      SignedXml.ComputeSignature();
+
+      // Get the XML representation of the signature and save
+      // it to an XmlElement object.
+      xmlSignature := SignedXml.GetXml();
+
+      // Append the element to the XML document.
+      XmlDocument.DocumentElement.AppendChild(XmlDocument.ImportNode(xmlSignature, TRUE));
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/Test/COD50016.txt
+++ b/Test/COD50016.txt
@@ -1,0 +1,144 @@
+OBJECT Codeunit 50016 Signed Xml Test
+{
+  OBJECT-PROPERTIES
+  {
+    Date=26/01/18;
+    Time=10:37:03;
+    Modified=Yes;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    Subtype=Test;
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      errSignedXmlTextTestFailed@1000000000 : TextConst 'ENU=Xml Document Text signature test failed;ENG=Xml Document Text signature test failed';
+      errSignedXmlStreamTestFailed@1000000001 : TextConst 'ENU=Xml Document Stream signature test failed;ENG=Xml Document Stream signature test failed';
+      errSignedXmlHardcodedTextTestFailed@1000000002 : TextConst 'ENU=Hardcoded Xml Document signature test failed;ENG=Hardcoded Xml Document signature test failed';
+      errIncorrectSignedXmlTestFailed@1000000003 : TextConst 'ENU="Incorrect xml document signature test failed ";ENG="Incorrect xml document signature test failed "';
+
+    [Test]
+    PROCEDURE TestSignedXmlText@1000000000();
+    VAR
+      SignedXmlMgt@1000000001 : Codeunit 50015;
+      Convert@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Convert";
+      RSAKey@1000000000 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Security.Cryptography.RSACryptoServiceProvider";
+      PrivateKey@1000000003 : Text;
+      PublicKey@1000000004 : Text;
+      XmlText@1000000005 : Text;
+      SignedXmlText@1000000006 : Text;
+    BEGIN
+      RSAKey := RSAKey.RSACryptoServiceProvider();
+
+      PrivateKey := Convert.ToBase64String(RSAKey.ExportCspBlob(TRUE));
+      PublicKey := Convert.ToBase64String(RSAKey.ExportCspBlob(FALSE));
+
+      XmlText := '<xml><data>something</data><data>another node</data></xml>';
+
+      //sign document
+      SignedXmlText := SignedXmlMgt.SignXmlText(XmlText, PrivateKey);
+
+      //test CheckXMlTestSignature function
+      IF (NOT(SignedXmlMgt.CheckXmlTextSignature(SignedXmlText, PublicKey))) THEN
+        ERROR(errSignedXmlTextTestFailed);
+    END;
+
+    [Test]
+    PROCEDURE TestSignedXmlStream@1000000002();
+    VAR
+      TempBlob@1000000007 : Record 99008535;
+      InputStream@1000000008 : InStream;
+      OutputStream@1000000009 : OutStream;
+      SignedXmlMgt@1000000001 : Codeunit 50015;
+      Convert@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Convert";
+      RSAKey@1000000000 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Security.Cryptography.RSACryptoServiceProvider";
+      PrivateKey@1000000003 : Text;
+      PublicKey@1000000004 : Text;
+      XmlText@1000000005 : Text;
+      SignedXmlText@1000000006 : Text;
+    BEGIN
+      RSAKey := RSAKey.RSACryptoServiceProvider();
+
+      PrivateKey := Convert.ToBase64String(RSAKey.ExportCspBlob(TRUE));
+      PublicKey := Convert.ToBase64String(RSAKey.ExportCspBlob(FALSE));
+
+      XmlText := '<xml><data>something</data><data>another node</data></xml>';
+
+      //sign document
+      SignedXmlText := SignedXmlMgt.SignXmlText(XmlText, PrivateKey);
+
+      //test CheckXmlStreamSignature function
+      CLEAR(TempBlob);
+      TempBlob.Blob.CREATEOUTSTREAM(OutputStream);
+      OutputStream.WRITETEXT(SignedXmlText);
+      TempBlob.Blob.CREATEINSTREAM(InputStream);
+      IF (NOT(SignedXmlMgt.CheckXmlStreamSignature(InputStream, PublicKey))) THEN
+        ERROR(errSignedXmlStreamTestFailed);
+    END;
+
+    [Test]
+    PROCEDURE TestHardcodedValidXml@1000000003();
+    VAR
+      SignedXmlMgt@1000000000 : Codeunit 50015;
+      PublicKey@1000000004 : Text;
+      XmlText@1000000005 : Text;
+      SignedXmlText@1000000006 : Text;
+    BEGIN
+      //test valid hardcoded xml document and public key
+      SignedXmlText := '<xml><data>something</data><data>another node</data>' +
+        '<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">' +
+        '<SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />' +
+        '<SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" /><Reference URI="">' +
+        '<Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />' +
+        '</Transforms><DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />' +
+        '<DigestValue>VhH7n9U2xFJSPDRmd1ssLb2kn9w=</DigestValue></Reference></SignedInfo>' +
+        '<SignatureValue>PGxNsb7HfG9wtKMdzozJJ59Hdnf8Q+lVU65L6RW5qlju9ZhkUvjZMEGKAtFD38AgbR3sD' +
+        'TMjyyY/5XriMZNDhE8NGOPOA7ZPoFVUkc1cCbvAFKmsxlz8zP3TBfrsL9jkBpdQi9rJKltAqI62NzPu/lkexb' +
+        '6vPh9y5rPLZG7hH/g=</SignatureValue></Signature></xml>';
+
+      PublicKey := 'BgIAAACkAABSU0ExAAQAAAEAAQBr/IYd2end7HQ9Q9a7IH4uZhb6ICQ1Nqv4rbrW4ftOa96sHpMn4vPMfx9Nd2G4vN0RZLB' +
+        'JzODADPyqwJmxwATD420PY5Tj8LUxBh60erCsxtc002551ggOxLAJFgfli3TtezAmT8uyoVj+SQ/wElfZqmMGADQVZ99QQt' +
+        'N04lUOrA==';
+
+      IF (NOT(SignedXmlMgt.CheckXmlTextSignature(SignedXmlText, PublicKey))) THEN
+        ERROR(errSignedXmlHardcodedTextTestFailed);
+    END;
+
+    [Test]
+    PROCEDURE TestHardcodedInvalidXml@1000000004();
+    VAR
+      SignedXmlMgt@1000000003 : Codeunit 50015;
+      PublicKey@1000000002 : Text;
+      XmlText@1000000001 : Text;
+      SignedXmlText@1000000000 : Text;
+    BEGIN
+      //test invalid hardcoded xml document and public key
+      SignedXmlText := '<xml><data>something different</data><data>another node</data>' +
+        '<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">' +
+        '<SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />' +
+        '<SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" /><Reference URI="">' +
+        '<Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />' +
+        '</Transforms><DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />' +
+        '<DigestValue>VhH7n9U2xFJSPDRmd1ssLb2kn9w=</DigestValue></Reference></SignedInfo>' +
+        '<SignatureValue>PGxNsb7HfG9wtKMdzozJJ59Hdnf8Q+lVU65L6RW5qlju9ZhkUvjZMEGKAtFD38AgbR3sD' +
+        'TMjyyY/5XriMZNDhE8NGOPOA7ZPoFVUkc1cCbvAFKmsxlz8zP3TBfrsL9jkBpdQi9rJKltAqI62NzPu/lkexb' +
+        '6vPh9y5rPLZG7hH/g=</SignatureValue></Signature></xml>';
+
+      PublicKey := 'BgIAAACkAABSU0ExAAQAAAEAAQBr/IYd2end7HQ9Q9a7IH4uZhb6ICQ1Nqv4rbrW4ftOa96sHpMn4vPMfx9Nd2G4vN0RZLB' +
+        'JzODADPyqwJmxwATD420PY5Tj8LUxBh60erCsxtc002551ggOxLAJFgfli3TtezAmT8uyoVj+SQ/wElfZqmMGADQVZ99QQt' +
+        'N04lUOrA==';
+
+      IF (SignedXmlMgt.CheckXmlTextSignature(SignedXmlText, PublicKey)) THEN
+        ERROR(errIncorrectSignedXmlTestFailed);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+


### PR DESCRIPTION
Support for signing and validating signature of signed xml documents using SignedXml .net class. Code is based on msdn examples available here: 

https://msdn.microsoft.com/en-us/library/system.security.cryptography.xml.signedxml(v=vs.110).aspx

