### PR TITLE
New Objects for executing Reports with RequestPages from External

### DIFF
--- a/BaseApp/COD50000.txt
+++ b/BaseApp/COD50000.txt
@@ -1,0 +1,276 @@
+OBJECT Codeunit 50000 Report Helper
+{
+  OBJECT-PROPERTIES
+  {
+    Date=27.02.18;
+    Time=09:44:37;
+    Modified=Yes;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+
+    PROCEDURE GetReportRequestPageStructureAsXml@6002002(ReportID@6003000 : Integer;LanguageID@6003001 : Integer;VAR ReturnValue@6003002 : Text);
+    VAR
+      Field@6004000 : Record 2000000041;
+      AllObjWithCaption@1109100008 : Record 2000000058;
+      Caption@6004006 : Text;
+      DataType@6004005 : Text;
+      Id@1109100006 : Text;
+      Name@1109100005 : Text;
+      TableCap@6004007 : Text;
+      FieldNumber@6004003 : Integer;
+      I@6004001 : Integer;
+      TableNo@6004004 : Integer;
+      DataItemList@6004008 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlNodeList";
+      InputParam@6004009 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlElement";
+      InputParameters@6004010 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlNodeList";
+      ResultXmlDocument@1109100000 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlDocument";
+      XmlAttribute@1109100003 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlAttribute";
+      XmlDocument@6004011 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlDocument";
+      XmlElement@1109100001 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlElement";
+      XmlElement2@1109100007 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlElement";
+      XmlElement3@1109100002 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlElement";
+      XmlExpression@6004012 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlElement";
+      XmlNamespaceManager@6004013 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlNamespaceManager";
+      XmlNode@1109100004 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlNode";
+    BEGIN
+      GetObjectMetadata(ReportID,XmlDocument);
+
+      IF ISNULL(XmlNamespaceManager) THEN BEGIN
+        XmlNamespaceManager := XmlNamespaceManager.XmlNamespaceManager(XmlDocument.NameTable);
+        XmlNamespaceManager.AddNamespace('xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+        XmlNamespaceManager.AddNamespace('xsd', 'http://www.w3.org/2001/XMLSchema');
+        XmlNamespaceManager.AddNamespace('ns1', 'urn:schemas-microsoft-com:dynamics:NAV:MetaObjects');
+      END;
+
+      XmlNode := XmlDocument.SelectSingleNode('/Report/ID');
+      Id := XmlNode.InnerText;
+
+      XmlNode := XmlDocument.SelectSingleNode('/Report/Name');
+      Name := XmlNode.InnerText;
+
+      ResultXmlDocument := ResultXmlDocument.XmlDocument;
+      XmlElement := ResultXmlDocument.CreateElement('ReportParameters');
+
+      XmlAttribute := ResultXmlDocument.CreateAttribute('name');
+      XmlAttribute.Value := Name;
+      XmlElement.Attributes.Append(XmlAttribute);
+
+      XmlAttribute := ResultXmlDocument.CreateAttribute('id');
+      XmlAttribute.Value := Id;
+      XmlElement.Attributes.Append(XmlAttribute);
+
+      ResultXmlDocument.AppendChild(XmlElement);
+
+      XmlElement2 := ResultXmlDocument.CreateElement('Options');
+      XmlElement.AppendChild(XmlElement2);
+
+      InputParameters := XmlDocument.SelectNodes('//ns1:Controls[@xsi:type=''ControlDefinition'']',XmlNamespaceManager);
+
+      IF InputParameters.Count <> 0 THEN
+        FOR I := 0 TO InputParameters.Count-1 DO BEGIN
+          InputParam := InputParameters.Item(I);
+          XmlElement3 := ResultXmlDocument.CreateElement('Field');
+          XmlElement2.AppendChild(XmlElement3);
+
+          XmlAttribute := ResultXmlDocument.CreateAttribute('name');
+          XmlExpression := XmlDocument.SelectSingleNode(STRSUBSTNO('//ns1:Expression[@Name=''%1'']',InputParam.GetAttribute('DataColumnName')),XmlNamespaceManager);
+          XmlAttribute.Value := XmlExpression.GetAttribute('SourceExpression');
+
+          XmlElement3.Attributes.Append(XmlAttribute);
+
+          XmlAttribute := ResultXmlDocument.CreateAttribute('datatype');
+
+          DataType := XmlExpression.GetAttribute('Datatype');
+          IF DataType = '' THEN BEGIN
+            EVALUATE(TableNo,XmlExpression.GetAttribute('TableNo'));
+            EVALUATE(FieldNumber,XmlExpression.GetAttribute('FieldNo'));
+            IF Field.GET(TableNo,FieldNumber) THEN
+              DataType := FORMAT(Field.Type);
+          END;
+
+          XmlAttribute.Value := DataType;
+          XmlElement3.Attributes.Append(XmlAttribute);
+
+          XmlAttribute := ResultXmlDocument.CreateAttribute('caption');
+          XmlAttribute.Value := GetTextFromTextML(InputParam.GetAttribute('CaptionML'),LanguageID);
+          XmlElement3.Attributes.Append(XmlAttribute);
+
+          IF XmlExpression.GetAttribute('OptionString') <> '' THEN BEGIN
+            XmlAttribute := ResultXmlDocument.CreateAttribute('optionstring');
+            XmlAttribute.Value := XmlExpression.GetAttribute('OptionString');
+            XmlElement3.Attributes.Append(XmlAttribute);
+
+            XmlAttribute := ResultXmlDocument.CreateAttribute('optioncaption');
+            XmlAttribute.Value := GetTextFromTextML(InputParam.GetAttribute('OptionCaptionML'),LanguageID);
+            XmlElement3.Attributes.Append(XmlAttribute);
+          END;
+        END;
+
+      XmlElement2 := ResultXmlDocument.CreateElement('DataItems');
+      XmlElement.AppendChild(XmlElement2);
+
+      DataItemList := XmlDocument.SelectNodes('//DataItem/DataItemVarName');
+      InputParameters := XmlDocument.SelectNodes('//ns1:Controls[@xsi:type=''FilterControlDefinition'']',XmlNamespaceManager);
+
+      IF InputParameters.Count <> 0 THEN BEGIN
+        FOR I := 0 TO InputParameters.Count-1 DO BEGIN
+          InputParam := InputParameters.Item(I);
+          XmlElement3 := ResultXmlDocument.CreateElement('DataItem');
+          XmlElement2.AppendChild(XmlElement3);
+
+          XmlAttribute := ResultXmlDocument.CreateAttribute('name');
+          XmlAttribute.Value := DataItemList.Item(I).InnerText;
+          XmlElement3.Attributes.Append(XmlAttribute);
+
+          XmlAttribute := ResultXmlDocument.CreateAttribute('table');
+          XmlAttribute.Value := InputParam.GetAttribute('FilterTableID');
+          XmlElement3.Attributes.Append(XmlAttribute);
+
+          EVALUATE(TableNo,XmlAttribute.Value);
+
+          IF AllObjWithCaption.GET(AllObjWithCaption."Object Type"::Table,TableNo) THEN
+            TableCap := AllObjWithCaption."Object Caption"
+          ELSE
+            TableCap := '';
+
+          XmlAttribute := ResultXmlDocument.CreateAttribute('caption');
+          XmlExpression := InputParam.SelectSingleNode('..');
+          Caption := GetTextFromTextML(XmlExpression.GetAttribute('CaptionML'),LanguageID);
+          IF Caption = '' THEN
+            Caption := TableCap;
+          XmlAttribute.Value := Caption;
+          XmlElement3.Attributes.Append(XmlAttribute);
+
+          XmlAttribute := ResultXmlDocument.CreateAttribute('visible');
+          XmlExpression := InputParam.SelectSingleNode('./ns1:DataItemTableView/ns1:Sorting',XmlNamespaceManager);
+          XmlAttribute.Value := FORMAT(ISNULL(XmlExpression),0,9);
+          XmlElement3.Attributes.Append(XmlAttribute);
+
+          XmlAttribute := ResultXmlDocument.CreateAttribute('requestfilterfields');
+          XmlAttribute.Value :=  FillRequestFieldData(InputParam);
+          XmlElement3.Attributes.Append(XmlAttribute);
+        END;
+      END;
+
+      ReturnValue := ResultXmlDocument.OuterXml;
+    END;
+
+    LOCAL PROCEDURE GetObjectMetadata@6002008(ReportID@6003000 : Integer;VAR XmlDocument@6003001 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlDocument");
+    VAR
+      ObjectMetadata@6004000 : Record 2000000071;
+      NAVAppObjectMetadata@1109100000 : Record 2000000150;
+      NAVInstream@6004001 : InStream;
+      ReportDoesNotExistErr@1109100001 : TextConst 'DEU=Der angegebene Bericht mit der Nummer %1 existiert nicht!;ENU=The specified report with the number %1 does not exist!';
+      MemoryStream@6004002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.IO.MemoryStream";
+    BEGIN
+      IF ObjectMetadata.GET(ObjectMetadata."Object Type"::Report,ReportID) THEN BEGIN
+        ObjectMetadata.CALCFIELDS(Metadata);
+
+        MemoryStream := MemoryStream.MemoryStream;
+        ObjectMetadata.Metadata.CREATEINSTREAM(NAVInstream);
+        COPYSTREAM(MemoryStream,NAVInstream);
+        MemoryStream.Position := 0;
+      END ELSE BEGIN
+        NAVAppObjectMetadata.RESET;
+        NAVAppObjectMetadata.SETRANGE("Metadata Format",NAVAppObjectMetadata."Metadata Format"::Full);
+        NAVAppObjectMetadata.SETRANGE("Object Type",NAVAppObjectMetadata."Object Type"::Report);
+        NAVAppObjectMetadata.SETRANGE("Object ID",ReportID);
+        IF NOT NAVAppObjectMetadata.FINDFIRST THEN
+          ERROR(ReportDoesNotExistErr,ReportID);
+
+        MemoryStream := MemoryStream.MemoryStream;
+        NAVAppObjectMetadata.Metadata.CREATEINSTREAM(NAVInstream);
+        COPYSTREAM(MemoryStream,NAVInstream);
+        MemoryStream.Position := 0;
+      END;
+
+      XmlDocument := XmlDocument.XmlDocument;
+      XmlDocument.Load(MemoryStream);
+    END;
+
+    LOCAL PROCEDURE FillRequestFieldData@6002014(VAR InputParam@6003001 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlElement") ResultText : Text;
+    VAR
+      ReqFilterFields@6004000 : Text;
+      FieldID@6004002 : Integer;
+      I@6004001 : Integer;
+      RegEx@6004003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Regex";
+      RegExMatch@6004005 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match";
+      RegExMatchCollection@6004004 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.MatchCollection";
+    BEGIN
+      ReqFilterFields := InputParam.GetAttribute('ReqFilterFields');
+      RegExMatchCollection := RegEx.Matches(ReqFilterFields,'Field(?<FieldNo>[0-9]*)');
+      IF RegExMatchCollection.Count = 0 THEN
+        EXIT('');
+
+      FOR I := 0 TO RegExMatchCollection.Count - 1
+      DO BEGIN
+        IF I <> 0 THEN
+          ResultText += ',';
+
+        RegExMatch := RegExMatchCollection.Item(I);
+        EVALUATE(FieldID,RegExMatch.Groups.Item('FieldNo').Value);
+        ResultText += FORMAT(FieldID,0,9);
+      END;
+    END;
+
+    LOCAL PROCEDURE GetTextFromTextML@6002018(TextML@6003000 : Text;LanguageID@1109100000 : Integer) : Text;
+    VAR
+      WindowsLang@6004001 : Record 2000000045;
+      WindowsLang2@1109100002 : Record 2000000045;
+      RetValue@1109100003 : Text;
+      I@6004007 : Integer;
+      RegEx@6004002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Regex";
+      RegExGroup@6004005 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Group";
+      RegExGroup2@1109100001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Group";
+      RegExGroup3@1109100004 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Group";
+      RegExMatch@6004004 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match";
+      RegExMatchCollection@6004003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.MatchCollection";
+      ReturnValue@6004006 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.String";
+    BEGIN
+      WindowsLang.GET(LanguageID);
+      WindowsLang2.GET(1033);
+
+      RegExMatchCollection := RegEx.Matches(TextML,'(?<Language>[A-Z]*)\=(?<Text>([^\;]*|\"(\"\"|[^\"])*\"))');
+
+      FOR I := 0 TO RegExMatchCollection.Count - 1
+      DO BEGIN
+        RegExMatch := RegExMatchCollection.Item(I);
+        RegExGroup := RegExMatch.Groups.Item('Language');
+        IF RegExGroup.Value = WindowsLang."Abbreviated Name" THEN
+          RegExGroup2 := RegExMatch.Groups.Item('Text');
+        IF RegExGroup.Value = WindowsLang2."Abbreviated Name" THEN
+          RegExGroup3 := RegExMatch.Groups.Item('Text');
+      END;
+
+      IF ISNULL(RegExGroup2) THEN BEGIN
+        IF NOT ISNULL(RegExGroup3) THEN
+          ReturnValue := RegExGroup3.Value;
+      END ELSE
+        ReturnValue := RegExGroup2.Value;
+
+      IF NOT ISNULL(ReturnValue) THEN BEGIN
+        IF ReturnValue.StartsWith('"') THEN BEGIN
+          ReturnValue := ReturnValue.Replace('""','"');
+          ReturnValue := ReturnValue.Substring(1,ReturnValue.Length - 2);
+        END;
+
+        RetValue := ReturnValue;
+        EXIT(RetValue);
+      END;
+
+      EXIT('');
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/Test/COD50001.txt
+++ b/Test/COD50001.txt
@@ -1,0 +1,145 @@
+OBJECT Codeunit 50001 Report Helper Tests
+{
+  OBJECT-PROPERTIES
+  {
+    Date=27.02.18;
+    Time=09:44:37;
+    Modified=Yes;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    Subtype=Test;
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+
+    [Test]
+    PROCEDURE TestRequestPageHelperReport205@1109100000();
+    VAR
+      ReportHelper@1109100000 : Codeunit 50000;
+      ResultXmlDocument@1109100001 : Text;
+      DataItemNotFoundErr@1109100007 : TextConst 'DEU=Das DataItem %1 kann nicht gefunden werden, obwohl es existiert!;ENU=DataItem %1 cannot be found although it exists!';
+      DataTypeNotExpErr@1109100008 : TextConst 'DEU=Der Datentyp %1 wurde erwartet.;ENU=The data type %1 was expected.';
+      NodeNotFoundErr@1109100005 : TextConst 'DEU=Der angegebene Knoten %1 kann nicht gefunden werden.;ENU=The specified node %1 cannot be found.';
+      ParamFoundErr@1109100006 : TextConst 'DEU=Der Knoten %1 wird gefunden, obowhl dieser nicht exisitert!;ENU=The node %1 is found, whether it does not exist!';
+      XmlDocument@1109100004 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlDocument";
+      XmlNode@1109100002 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlElement";
+    BEGIN
+      ReportHelper.GetReportRequestPageStructureAsXml(REPORT::"Order Confirmation",GLOBALLANGUAGE,ResultXmlDocument);
+      XmlDocument := XmlDocument.XmlDocument;
+      XmlDocument.LoadXml(ResultXmlDocument);
+
+      XmlNode := XmlDocument.SelectSingleNode('/ReportParameters/Options/Field[@name=''NoOfCopies'']');
+      IF ISNULL(XmlNode) THEN
+        ERROR(NodeNotFoundErr,'NoOfCopies');
+
+      IF XmlNode.GetAttribute('datatype') <> 'Integer' THEN
+        ERROR(DataTypeNotExpErr,'Integer');
+
+      XmlNode := XmlDocument.SelectSingleNode('/ReportParameters/Options/Field[@name=''ArchiveDocument'']');
+      IF ISNULL(XmlNode) THEN
+        ERROR(NodeNotFoundErr,'ArchiveDocument');
+
+      XmlNode := XmlDocument.SelectSingleNode('/ReportParameters/Options/Field[@name=''Test'']');
+      IF NOT ISNULL(XmlNode) THEN
+        ERROR(ParamFoundErr,'Test');
+
+      XmlNode := XmlDocument.SelectSingleNode('/ReportParameters/DataItems/DataItem[@name=''VATCounterLCY'']');
+      IF ISNULL(XmlNode) THEN
+        ERROR(DataItemNotFoundErr,'VATCounterLCY');
+    END;
+
+    [Test]
+    PROCEDURE TestRequestPageHelperReport111@1109100001();
+    VAR
+      ReportHelper@1109100000 : Codeunit 50000;
+      ResultXmlDocument@1109100001 : Text;
+      DataItemNotFoundErr@1109100007 : TextConst 'DEU=Das DataItem %1 kann nicht gefunden werden, obwohl es existiert!;ENU=DataItem %1 cannot be found although it exists!';
+      NodeNotFoundErr@1109100005 : TextConst 'DEU=Der angegebene Knoten %1 kann nicht gefunden werden.;ENU=The specified node %1 cannot be found.';
+      OptionStringErr@1109100008 : TextConst 'DEU=Es wurde ein OptionString erwartet, zurÅckgegeben wurde jedoch ein leeres Ergebnis!;ENU=An OptionString was expected, but returned an empty result!';
+      ParamFoundErr@1109100006 : TextConst 'DEU=Der Knoten %1 wird gefunden, obowhl dieser nicht exisitert!;ENU=The node %1 is found, whether it does not exist!';
+      XmlDocument@1109100004 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlDocument";
+      XmlNode@1109100002 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlElement";
+    BEGIN
+      ReportHelper.GetReportRequestPageStructureAsXml(REPORT::"Customer - Top 10 List",GLOBALLANGUAGE,ResultXmlDocument);
+      XmlDocument := XmlDocument.XmlDocument;
+      XmlDocument.LoadXml(ResultXmlDocument);
+      XmlNode := XmlDocument.SelectSingleNode('/ReportParameters/Options/Field[@name=''ShowType'']');
+      IF ISNULL(XmlNode) THEN
+        ERROR(NodeNotFoundErr,'ShowType');
+
+      IF XmlNode.GetAttribute('optionstring') = '' THEN
+        ERROR(OptionStringErr);
+
+      XmlNode := XmlDocument.SelectSingleNode('/ReportParameters/Options/Field[@name=''NoOfRecordsToPrint'']');
+      IF ISNULL(XmlNode) THEN
+        ERROR(NodeNotFoundErr,'NoOfRecordsToPrint');
+
+      XmlNode := XmlDocument.SelectSingleNode('/ReportParameters/Options/Field[@name=''Test'']');
+      IF NOT ISNULL(XmlNode) THEN
+        ERROR(ParamFoundErr,'Test');
+
+      XmlNode := XmlDocument.SelectSingleNode('/ReportParameters/DataItems/DataItem[@name=''Customer'']');
+      IF ISNULL(XmlNode) THEN
+        ERROR(DataItemNotFoundErr,'Customer');
+    END;
+
+    [Test]
+    PROCEDURE TestRequestPageHelperReport1@1109100006();
+    VAR
+      ReportHelper@1109100000 : Codeunit 50000;
+      ResultXmlDocument@1109100001 : Text;
+      DataItemNotFoundErr@1109100007 : TextConst 'DEU=Das DataItem %1 kann nicht gefunden werden, obwohl es existiert!;ENU=DataItem %1 cannot be found although it exists!';
+      ParamFoundErr@1109100006 : TextConst 'DEU=Der Knoten %1 wird gefunden, obowhl dieser nicht exisitert!;ENU=The node %1 is found, whether it does not exist!';
+      RequestFieldsErr@1109100009 : TextConst 'DEU=Es wurden RequestFilterFields erwartet!;ENU=RequestFilterFields were expected!';
+      XmlDocument@1109100004 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlDocument";
+      XmlNode@1109100002 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlElement";
+    BEGIN
+      ReportHelper.GetReportRequestPageStructureAsXml(REPORT::"Chart of Accounts",GLOBALLANGUAGE,ResultXmlDocument);
+      XmlDocument := XmlDocument.XmlDocument;
+      XmlDocument.LoadXml(ResultXmlDocument);
+
+      XmlNode := XmlDocument.SelectSingleNode('/ReportParameters/Options/Field[@name=''Test'']');
+      IF NOT ISNULL(XmlNode) THEN
+        ERROR(ParamFoundErr,'Test');
+
+      XmlNode := XmlDocument.SelectSingleNode('/ReportParameters/DataItems/DataItem[@name=''G/L Account'']');
+      IF ISNULL(XmlNode) THEN
+        ERROR(DataItemNotFoundErr,'G/L Account');
+
+      IF XmlNode.GetAttribute('requestfilterfields') = '' THEN
+        ERROR(RequestFieldsErr);
+    END;
+
+    [Test]
+    PROCEDURE TestRequestPageHelperReport34@1109100010();
+    VAR
+      ReportHelper@1109100000 : Codeunit 50000;
+      ResultXmlDocument@1109100001 : Text;
+      NoDataItemFoundErr@1109100010 : TextConst 'DEU=Es wurden keine DataItems erwartet.;ENU=No data items were expected.';
+      ParamFoundErr@1109100006 : TextConst 'DEU=Der Knoten %1 wird gefunden, obowhl dieser nicht exisitert!;ENU=The node %1 is found, whether it does not exist!';
+      XmlDocument@1109100004 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlDocument";
+      XmlNode@1109100002 : DotNet "'System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Xml.XmlElement";
+    BEGIN
+      ReportHelper.GetReportRequestPageStructureAsXml(REPORT::"Change Payment Tolerance",GLOBALLANGUAGE,ResultXmlDocument);
+      XmlDocument := XmlDocument.XmlDocument;
+      XmlDocument.LoadXml(ResultXmlDocument);
+
+      XmlNode := XmlDocument.SelectSingleNode('/ReportParameters/Options/Field[@name=''Test'']');
+      IF NOT ISNULL(XmlNode) THEN
+        ERROR(ParamFoundErr,'Test');
+
+      XmlNode := XmlDocument.SelectSingleNode('/ReportParameters/DataItems/DataItem');
+      IF NOT ISNULL(XmlNode) THEN
+        ERROR(NoDataItemFoundErr);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+


### PR DESCRIPTION
This point refers to Issue [546](https://github.com/Microsoft/AL/issues/546) of Microsoft/AL. In it the request was introduced to make it possible to read out the options and data items of the request page via the object metadata table. Unfortunately, the NAV standard does not allow to do this. And retrieval of the Request XML document is only possible when the client is started and the RequestPage is displayed to the user. Furthermore, a lot of important information is missing to prepare this XML document accordingly. This customization is required to start a report and request page from an external Web service, and to obtain the required request parameters in order to be able to build up the XML required by NAV. The generated XML has the same structure as the query XML file, which can be passed to the REPORT.SAVE function. Only the missing options such as data type and additional information have been added.