### PR TITLE
SmtpMessage wrapper

### DIFF
--- a/BaseApp/COD50008.txt
+++ b/BaseApp/COD50008.txt
@@ -1,0 +1,126 @@
+OBJECT Codeunit 50008 DotNet_SmtpMessage
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Modified=Yes;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetSmtpMessage@17024400 : DotNet "'Microsoft.Dynamics.Nav.SMTP, Version=11.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.Microsoft.Dynamics.Nav.SMTP.SmtpMessage";
+
+    [External]
+    PROCEDURE CreateMessage@17024401();
+    BEGIN
+      DotNetSmtpMessage := DotNetSmtpMessage.SmtpMessage;
+    END;
+
+    [External]
+    PROCEDURE SetFromAddress@17024402(FromAddress@17024400 : Text);
+    BEGIN
+      DotNetSmtpMessage.FromAddress := FromAddress;
+    END;
+
+    [External]
+    PROCEDURE SetFromName@17024403(FromName@17024400 : Text);
+    BEGIN
+      DotNetSmtpMessage.FromAddress := FromName;
+    END;
+
+    [External]
+    PROCEDURE SetToAddress@17024405(ToAddress@17024400 : Text);
+    BEGIN
+      DotNetSmtpMessage."To" := ToAddress;
+    END;
+
+    [External]
+    PROCEDURE SetSubject@17024410(Subject@17024400 : Text);
+    BEGIN
+      DotNetSmtpMessage.Subject := Subject;
+    END;
+
+    [External]
+    PROCEDURE SetAsHtmlFormatted@17024408(HtmlFormatted@17024400 : Boolean);
+    BEGIN
+      DotNetSmtpMessage.HtmlFormatted := HtmlFormatted;
+    END;
+
+    [External]
+    PROCEDURE SetTimeout@17024424(Timeout@17024400 : Integer);
+    BEGIN
+      DotNetSmtpMessage.Timeout := Timeout;
+      DotNetSmtpMessage.ConvertBase64ImagesToContentId
+    END;
+
+    [External]
+    PROCEDURE ClearBody@17024412();
+    BEGIN
+      DotNetSmtpMessage.Body := '';
+    END;
+
+    [External]
+    PROCEDURE AppendToBody@17024413(Text@17024400 : Text);
+    BEGIN
+      DotNetSmtpMessage.AppendBody(Text);
+    END;
+
+    [External]
+    PROCEDURE AddRecipients@17024415(AddressToAdd@17024401 : Text);
+    BEGIN
+      DotNetSmtpMessage.AddRecipients(AddressToAdd);
+    END;
+
+    [External]
+    PROCEDURE AddCC@17024418(AddressToAdd@17024401 : Text);
+    BEGIN
+      DotNetSmtpMessage.AddCC(AddressToAdd);
+    END;
+
+    [External]
+    PROCEDURE AddBCC@17024419(AddressToAdd@17024401 : Text);
+    BEGIN
+      DotNetSmtpMessage.AddBCC(AddressToAdd);
+    END;
+
+    [External]
+    PROCEDURE AddAttachment@17024417(AttachmentStream@17024401 : InStream;AttachmentName@17024400 : Text);
+    BEGIN
+      DotNetSmtpMessage.AddAttachment(AttachmentStream, AttachmentName);
+    END;
+
+    [External]
+    PROCEDURE SendMail@17024421(ServerName@17024401 : Text;ServerPort@17024400 : Integer;UseAuthentication@17024402 : Boolean;Username@17024403 : Text;Password@17024404 : Text;UseSSL@17024405 : Boolean) : Text;
+    BEGIN
+      EXIT(DotNetSmtpMessage.Send(ServerName, ServerPort, UseAuthentication, Username, Password, UseSSL));
+    END;
+
+    [External]
+    PROCEDURE ConvertBase64ImagesToContentId@17024426(UseConvertBase64ImagesToContentId@17024400 : Boolean) : Boolean;
+    BEGIN
+      DotNetSmtpMessage.ConvertBase64ImagesToContentId();
+    END;
+
+    PROCEDURE GetSmtpMessage@4(VAR CurrentDotNetSmtpMessage@17024400 : DotNet "'Microsoft.Dynamics.Nav.SMTP, Version=11.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.Microsoft.Dynamics.Nav.SMTP.SmtpMessage");
+    BEGIN
+      CurrentDotNetSmtpMessage := DotNetSmtpMessage;
+    END;
+
+    PROCEDURE SetSmtpMessage@5(NewDotNetSmtpMessage@17024400 : DotNet "'Microsoft.Dynamics.Nav.SMTP, Version=11.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.Microsoft.Dynamics.Nav.SMTP.SmtpMessage");
+    BEGIN
+      DotNetSmtpMessage := NewDotNetSmtpMessage;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/Test/COD50009.txt
+++ b/Test/COD50009.txt
@@ -1,0 +1,98 @@
+OBJECT Codeunit 50009 Test_DotNet_SmtpMessage
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Modified=Yes;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    Subtype=Test;
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      Assert@17024400 : Codeunit 130000;
+      LibraryLowerPermissions@17024401 : Codeunit 132217;
+      DotNet_SmtpMessage@17024405 : Codeunit 50008;
+      DotNetSmtpMessage@17024402 : DotNet "'Microsoft.Dynamics.Nav.SMTP, Version=11.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.Microsoft.Dynamics.Nav.SMTP.SmtpMessage";
+
+    [Test]
+    PROCEDURE AddBCCTest@17024403();
+    BEGIN
+      DotNet_SmtpMessage.CreateMessage;
+      // [WHEN] one address is added to BCC
+      DotNet_SmtpMessage.AddBCC('testmail@mail.com');
+      DotNet_SmtpMessage.GetSmtpMessage(DotNetSmtpMessage);
+      // [THEN] Message BCC equals to added address
+      Assert.AreEqual('testmail@mail.com', DotNetSmtpMessage.Bcc, 'Bcc add failed');
+      // [WHEN] additional address is added to BCC
+      DotNet_SmtpMessage.AddBCC('testmail2@mail.com');
+      DotNet_SmtpMessage.GetSmtpMessage(DotNetSmtpMessage);
+      // [THEN] Message BCC equals to concatenation of both addresses
+      Assert.AreEqual('testmail@mail.com; testmail2@mail.com', DotNetSmtpMessage.Bcc, 'Bcc add failed');
+    END;
+
+    [Test]
+    PROCEDURE AddCCTest@17024408();
+    BEGIN
+      DotNet_SmtpMessage.CreateMessage;
+      // [WHEN] one address is added to CC
+      DotNet_SmtpMessage.AddCC('testmail@mail.com');
+      DotNet_SmtpMessage.GetSmtpMessage(DotNetSmtpMessage);
+      // [THEN] Message CC equals to added address
+      Assert.AreEqual('testmail@mail.com', DotNetSmtpMessage.CC, 'CC add failed');
+      // [WHEN] additional address is added to CC
+      DotNet_SmtpMessage.AddCC('testmail2@mail.com');
+      DotNet_SmtpMessage.GetSmtpMessage(DotNetSmtpMessage);
+      // [THEN] Message CC equals to concatenation of both addresses
+      Assert.AreEqual('testmail@mail.com; testmail2@mail.com', DotNetSmtpMessage.CC, 'CC add failed');
+    END;
+
+    [Test]
+    PROCEDURE AddRecipientTest@17024410();
+    BEGIN
+      DotNet_SmtpMessage.CreateMessage;
+      // [WHEN] one address is added to BCC
+      DotNet_SmtpMessage.SetToAddress('testmail@mail.com');
+      DotNet_SmtpMessage.GetSmtpMessage(DotNetSmtpMessage);
+      // [THEN] Message BCC equals to added address
+      Assert.AreEqual('testmail@mail.com', DotNetSmtpMessage."To", 'Recipient add failed');
+      // [WHEN] additional address is added to recipients
+      DotNet_SmtpMessage.AddRecipients('testmail2@mail.com');
+      DotNet_SmtpMessage.GetSmtpMessage(DotNetSmtpMessage);
+      // [THEN] Message Recipients equals to concatenation of both addresses
+      Assert.AreEqual('testmail@mail.com; testmail2@mail.com', DotNetSmtpMessage."To", 'Recipient add failed');
+    END;
+
+    [Test]
+    PROCEDURE AppendBodyTest@17024404();
+    BEGIN
+      DotNet_SmtpMessage.CreateMessage;
+      // [WHEN] body is cleared
+      DotNet_SmtpMessage.ClearBody;
+      DotNet_SmtpMessage.GetSmtpMessage(DotNetSmtpMessage);
+      // [THEN] Message body equals to empty string
+      Assert.AreEqual('', DotNetSmtpMessage.Body, 'Body manipulation failed');
+      // [WHEN] 'test1' is added to body
+      DotNet_SmtpMessage.AppendToBody('test1');
+      DotNet_SmtpMessage.GetSmtpMessage(DotNetSmtpMessage);
+      // [THEN] Message body equals to 'test1'
+      Assert.AreEqual('test1', DotNetSmtpMessage.Body, 'Body manipulation failed');
+      // [WHEN] additional text is added to body
+      DotNet_SmtpMessage.AppendToBody('test2');
+      DotNet_SmtpMessage.GetSmtpMessage(DotNetSmtpMessage);
+      // [THEN] Message body equals concatenation sof both strings
+      Assert.AreEqual('test1test2', DotNetSmtpMessage.Body, 'Body manipulation failed');
+    END;
+
+    BEGIN
+    END.
+  }
+}
+


### PR DESCRIPTION
Even so there is standard NAV functionality for sending Smtp Mail, in certain cases it is useful to have direct access to SmtpMessage DotNet class. This wrapper provides such possibility, so I think it is useful addition to C/AL open library