### PR TITLE
IEnumerable, IEnumerator, System.Object and System.Type wrapper

### DIFF
--- a/BaseApp/COD3000.TXT
+++ b/BaseApp/COD3000.TXT
@@ -4,6 +4,7 @@ OBJECT Codeunit 3000 DotNet_Array
   {
     Date=;
     Time=;
+    Modified=Yes;
     Version List=;
   }
   PROPERTIES
@@ -18,15 +19,48 @@ OBJECT Codeunit 3000 DotNet_Array
       DotNetArray@1000 : DotNet "'mscorlib'.System.Array";
 
     [External]
+    PROCEDURE Create@17024402(VAR ElementType@17024401 : Codeunit 50011;Length@17024400 : Integer) : Integer;
+    VAR
+      DotNetType@17024402 : DotNet "'mscorlib'.System.Type";
+    BEGIN
+      ElementType.GetType(DotNetType);
+      DotNetArray := DotNetArray.CreateInstance(DotNetType, Length);
+    END;
+
+    [External]
     PROCEDURE Length@4() : Integer;
     BEGIN
       EXIT(DotNetArray.Length)
     END;
 
     [External]
+    PROCEDURE SetValueAsObject@17024407(Index@1000 : Integer;VAR NewValue@17024400 : Codeunit 50010);
+    VAR
+      DotNetObject@17024401 : DotNet "'mscorlib'.System.Object";
+    BEGIN
+      NewValue.GetObject(DotNetObject);
+      DotNetArray.SetValue(DotNetObject, Index);
+    END;
+
+    [External]
+    PROCEDURE SetValueAsText@17024409(Index@1000 : Integer;NewValue@17024400 : Text);
+    VAR
+      DotNetString@17024401 : DotNet "'mscorlib'.System.String";
+    BEGIN
+      DotNetString := NewValue;
+      DotNetArray.SetValue(DotNetString, Index);
+    END;
+
+    [External]
     PROCEDURE GetValueAsText@5(Index@1000 : Integer) : Text;
     BEGIN
       EXIT(DotNetArray.GetValue(Index))
+    END;
+
+    [External]
+    PROCEDURE GetValueAsObject@17024405(Index@1000 : Integer;VAR CurrentValue@17024400 : Codeunit 50010);
+    BEGIN
+      CurrentValue.SetObject(DotNetArray.GetValue(Index));
     END;
 
     PROCEDURE GetArray@2(VAR DotNetArray2@1000 : DotNet "'mscorlib'.System.Array");
@@ -37,6 +71,12 @@ OBJECT Codeunit 3000 DotNet_Array
     PROCEDURE SetArray@3(DotNetArray2@1000 : DotNet "'mscorlib'.System.Array");
     BEGIN
       DotNetArray := DotNetArray2
+    END;
+
+    [External]
+    PROCEDURE AsEnumerable@17024400(VAR Enumerable@17024400 : Codeunit 50013);
+    BEGIN
+      Enumerable.SetEnumerable(DotNetArray);
     END;
 
     BEGIN

--- a/BaseApp/COD50010.TXT
+++ b/BaseApp/COD50010.TXT
@@ -1,0 +1,59 @@
+OBJECT Codeunit 50010 DotNet_Object
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Modified=Yes;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetObject@17024400 : DotNet "'mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Object" SUPPRESSDISPOSE;
+
+    PROCEDURE SetObject@17024409(NewObject@17024400 : DotNet "'mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Object");
+    BEGIN
+      DotNetObject := NewObject;
+    END;
+
+    PROCEDURE GetObject@17024410(VAR CurrentObject@17024400 : DotNet "'mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Object");
+    BEGIN
+      CurrentObject := DotNetObject;
+    END;
+
+    [External]
+    PROCEDURE GetTypeInfo@17024401(VAR DotNetType@17024400 : Codeunit 50011);
+    BEGIN
+      DotNetType.SetType(DotNetObject.GetType);
+    END;
+
+    [External]
+    PROCEDURE ToText@17024403() : Text;
+    BEGIN
+      EXIT(DotNetObject.ToString);
+    END;
+
+    [External]
+    PROCEDURE GetHashCode@17024404() : Integer;
+    BEGIN
+      EXIT(DotNetObject.GetHashCode);
+    END;
+
+    [External]
+    PROCEDURE IsEmpty@17024406() : Boolean;
+    BEGIN
+      EXIT(ISNULL(DotNetObject));
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50011.TXT
+++ b/BaseApp/COD50011.TXT
@@ -1,0 +1,56 @@
+OBJECT Codeunit 50011 DotNet_Type
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Modified=Yes;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetType@17024400 : DotNet "'mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Type";
+
+    PROCEDURE SetType@17024409(NewType@17024400 : DotNet "'mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Type");
+    BEGIN
+      DotNetType := NewType;
+    END;
+
+    PROCEDURE GetType@17024410(VAR CurrentObject@17024400 : DotNet "'mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Type");
+    BEGIN
+      CurrentObject := DotNetType;
+    END;
+
+    [External]
+    PROCEDURE GetAssemblyQualifiedName@17024401() : Text;
+    BEGIN
+      EXIT(DotNetType.AssemblyQualifiedName);
+    END;
+
+    [External]
+    PROCEDURE GetName@17024403() : Text;
+    BEGIN
+      EXIT(DotNetType.Name);
+    END;
+
+    [External]
+    PROCEDURE IsAssignableFrom@17024405(OtherType@17024400 : Codeunit 50011) : Boolean;
+    VAR
+      OtherDotNetType@17024401 : DotNet "'mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Type";
+    BEGIN
+      OtherType.GetType(OtherDotNetType);
+      EXIT(DotNetType.IsAssignableFrom(DotNetType));
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50012.TXT
+++ b/BaseApp/COD50012.TXT
@@ -1,0 +1,53 @@
+OBJECT Codeunit 50012 DotNet_IEnumerator
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Modified=Yes;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+
+    PROCEDURE SetEnumerator@17024415(NewEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      DotNetEnumerator := NewEnumerator;
+    END;
+
+    PROCEDURE GetEnumerator@17024414(VAR CurrentEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      CurrentEnumerator := DotNetEnumerator;
+    END;
+
+    [External]
+    PROCEDURE Reset@17024401();
+    BEGIN
+      DotNetEnumerator.Reset;
+    END;
+
+    [External]
+    PROCEDURE MoveNext@17024402() : Boolean;
+    BEGIN
+      EXIT(DotNetEnumerator.MoveNext);
+    END;
+
+    [External]
+    PROCEDURE GetCurrent@17024403(VAR CurrentObject@17024400 : Codeunit 50010);
+    BEGIN
+      CurrentObject.SetObject(DotNetEnumerator.Current);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50013.TXT
+++ b/BaseApp/COD50013.TXT
@@ -1,0 +1,41 @@
+OBJECT Codeunit 50013 DotNet_IEnumerable
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Modified=Yes;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetEnumerable@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerable";
+
+    PROCEDURE SetEnumerable@17024415(NewEnumerable@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerable");
+    BEGIN
+      DotNetEnumerable := NewEnumerable;
+    END;
+
+    PROCEDURE GetEnumerable@17024414(VAR CurrentEnumerable@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerable");
+    BEGIN
+      CurrentEnumerable := DotNetEnumerable;
+    END;
+
+    [External]
+    PROCEDURE GetEnumerator@17024403(VAR Enumerator@17024400 : Codeunit 50012);
+    BEGIN
+      Enumerator.SetEnumerator(DotNetEnumerable.GetEnumerator);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50014.TXT
+++ b/BaseApp/COD50014.TXT
@@ -1,0 +1,76 @@
+OBJECT Codeunit 50014 Test_DotNet_ObjectAndType
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Modified=Yes;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    Subtype=Test;
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      Assert@17024400 : Codeunit 130000;
+      LibraryLowerPermissions@17024401 : Codeunit 132217;
+      DotNet_Object@17024405 : Codeunit 50010;
+      DotNet_Type@17024402 : Codeunit 50011;
+      DotNet_Array@17024403 : Codeunit 3000;
+      DotNetObject@17024404 : DotNet "'mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Object" SUPPRESSDISPOSE;
+      DotNetString@17024406 : DotNet "'mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.String" SUPPRESSDISPOSE;
+
+    [Test]
+    PROCEDURE ObjectMethodsTest@17024401();
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[GIVEN] string with value 'TestString' is actual object
+      DotNetString := 'TestString';
+      //[WHEN] casting it to "object" .NET Type
+      DotNet_Object.SetObject(DotNetString);
+      //[THEN] ToString result should be equal to 'TestString'
+      Assert.AreEqual('TestString', DotNet_Object.ToText, 'Casting to object fails');
+      //[THEN] object values is not "null"
+      Assert.AreEqual(FALSE, DotNet_Object.IsEmpty, 'Checking if object is null fails');
+      DotNet_Object.GetTypeInfo(DotNet_Type);
+      //[THEN] type name of object is 'String'
+      Assert.AreEqual('String', DotNet_Type.GetName, 'Checking type fails');
+    END;
+
+    [Test]
+    PROCEDURE ArrayCreationAndModificationTest@17024404();
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      DotNetString := 'TestString';
+      //[GIVEN] System.String datatype is used as type base
+      DotNet_Type.SetType(DotNetString.GetType);
+      //[WHEN] Array of 3 elements is created
+      DotNet_Array.Create(DotNet_Type, 3);
+      //[WHEN] and first element is set to 'TestString' using object wrapper
+      DotNet_Object.SetObject(DotNetString);
+      DotNet_Array.SetValueAsObject(0, DotNet_Object);
+      //[WHEN] and second element is set to 'TestString2' directly
+      DotNet_Array.SetValueAsText(1, 'TestString2');
+      //[THEN] array length should be 3
+      Assert.AreEqual(3, DotNet_Array.Length, 'Length check fails');
+      //[THEN] first element should be 'TestString'
+      Assert.AreEqual('TestString', DotNet_Array.GetValueAsText(0), 'First element check fails');
+      //[THEN] second element should be 'TestString2'
+      DotNet_Array.GetValueAsObject(1, DotNet_Object);
+      DotNet_Object.GetObject(DotNetString);
+      Assert.AreEqual('TestString2', DotNetString.ToString, 'Second element check fails');
+      //[THEN] third element should be null
+      DotNet_Array.GetValueAsObject(2, DotNet_Object);
+      Assert.AreEqual(TRUE, DotNet_Object.IsEmpty, 'Third element check fails');
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50015.TXT
+++ b/BaseApp/COD50015.TXT
@@ -1,0 +1,83 @@
+OBJECT Codeunit 50015 Test_DotNet_Enumerator
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Modified=Yes;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    Subtype=Test;
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      Assert@17024400 : Codeunit 130000;
+      LibraryLowerPermissions@17024401 : Codeunit 132217;
+      DotNet_Object@17024405 : Codeunit 50010;
+      DotNet_Type@17024402 : Codeunit 50011;
+      DotNet_Array@17024403 : Codeunit 3000;
+      DotNetString@17024406 : DotNet "'mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.String" SUPPRESSDISPOSE;
+      DotNet_IEnumerator@17024407 : Codeunit 50012;
+      DotNet_IEnumerable@17024408 : Codeunit 50013;
+
+    [Test]
+    PROCEDURE StringEnumeratorTest@17024401();
+    VAR
+      Count@17024400 : Integer;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[GIVEN] 'TestString' as stored as .NET string
+      DotNetString := 'TestString';
+      //[WHEN] type is casted to IEnumerable and iteration is performed
+      DotNet_IEnumerable.SetEnumerable(DotNetString);
+      DotNet_IEnumerable.GetEnumerator(DotNet_IEnumerator);
+      Count := 0;
+      WHILE DotNet_IEnumerator.MoveNext DO
+        Count += 1;
+      //[THEN] iterations count should be equal to string length
+      Assert.AreEqual(DotNetString.Length, Count, 'Enumerator elements count fails');
+    END;
+
+    [Test]
+    PROCEDURE ArrayEnumeratorTest@17024412();
+    VAR
+      Count@17024400 : Integer;
+      Concatenation@17024401 : Text;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[GIVEN] a string array of 3 elements ('Value1', 'Value2', 'Value3')
+      DotNetString := '';
+      DotNet_Type.SetType(DotNetString.GetType);
+      DotNet_Array.Create(DotNet_Type, 3);
+      DotNet_Array.SetValueAsText(0, 'Value1');
+      DotNet_Array.SetValueAsText(1, 'Value2');
+      DotNet_Array.SetValueAsText(2, 'Value3');
+      //[WHEN] Array is casted to IEnumerable and iteration is performed
+      DotNet_Array.AsEnumerable(DotNet_IEnumerable);
+      DotNet_IEnumerable.GetEnumerator(DotNet_IEnumerator);
+      Count := 0;
+      Concatenation := '';
+      WHILE DotNet_IEnumerator.MoveNext DO
+        BEGIN
+          Count += 1;
+          DotNet_IEnumerator.GetCurrent(DotNet_Object);
+          DotNet_Object.GetObject(DotNetString);
+          Concatenation += DotNetString.ToString;
+        END;
+      //[THEN] iterations count should be equal to array length
+      Assert.AreEqual(DotNet_Array.Length, Count, 'Enumerator elements count fails');
+      //[THEN] and concatenation of all iterated values should be equal to 'Value1Value2Value3'
+      Assert.AreEqual('Value1Value2Value3', Concatenation, 'Enumerator elements count fails');
+    END;
+
+    BEGIN
+    END.
+  }
+}
+


### PR DESCRIPTION
I agree that this commit might be close to the limits of what should be allowed in C/AL Open Library, but I think this addition is needed and very useful, so let me explain everything. Basically all included objects is for IEnumerator support.
Almost all collections, lots of default methods and and etc. supports enumerators in .NET. So wrapper for IEnumerator is really needed to access this functionality. But the problem comes here - to support it in a generic way, we also need wrappers for System.Object and System.Type. System.Object wrapper allows to wrap the result of IEnumerator.Current and System.Type allows us to check the type name and whether type is assignable from. I tried making only safe methods of System.Type visible, so from my point of view it should be safe wrapper. Also I extended Array wrapper - it now can be converter to IEnumerator wrapper and we can also create it (using Type wrapper) and later modify.