### PR TITLE
DocumentFormat.OpenXml.WordProcessing namespace .NET wrappers

### DIFF
--- a/BaseApp/COD50018.TXT
+++ b/BaseApp/COD50018.TXT
@@ -1,0 +1,78 @@
+OBJECT Codeunit 50018 DotNet_WordprocessingDocument
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetWordprocessingDocument@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.WordprocessingDocument";
+      DotNetMemoryStream@17024402 : DotNet "'mscorlib'.System.IO.MemoryStream";
+
+    [External]
+    PROCEDURE Create@17024401(DocumentType@17024401 : 'Document,Template,MacroEnabledDocument,MacroEnabledTemplate';AutoSave@17024403 : Boolean);
+    VAR
+      DotNetWordprocessingDocumentType@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.WordprocessingDocumentType";
+    BEGIN
+      DotNetMemoryStream := DotNetMemoryStream.MemoryStream;
+      DotNetWordprocessingDocumentType := DotNetWordprocessingDocumentType.Parse(GETDOTNETTYPE(DotNetWordprocessingDocumentType), FORMAT(DocumentType, 0));
+      DotNetWordprocessingDocument := DotNetWordprocessingDocument.Create(DotNetMemoryStream, DotNetWordprocessingDocumentType, AutoSave);
+    END;
+
+    [External]
+    PROCEDURE Open@17024402(DocumentStream@17024401 : InStream;Editable@17024400 : Boolean);
+    BEGIN
+      DotNetMemoryStream := DotNetMemoryStream.MemoryStream;
+      COPYSTREAM(DotNetMemoryStream, DocumentStream);
+      DotNetMemoryStream.Position := 0;
+      DotNetWordprocessingDocument := DotNetWordprocessingDocument.Open(DotNetMemoryStream, Editable);
+    END;
+
+    [External]
+    PROCEDURE Close@17024407();
+    BEGIN
+      DotNetWordprocessingDocument.Close;
+    END;
+
+    [External]
+    PROCEDURE Save@17024408(ResultStream@17024400 : OutStream);
+    BEGIN
+      COPYSTREAM(ResultStream, DotNetMemoryStream);
+    END;
+
+    [External]
+    PROCEDURE AddMainDocumentPart@17024404(VAR MainDocumentPart@17024400 : Codeunit 50019);
+    BEGIN
+      MainDocumentPart.SetMainDocumentPart(DotNetWordprocessingDocument.AddMainDocumentPart);
+    END;
+
+    [External]
+    PROCEDURE GetMainDocumentPart@17024406(VAR MainDocumentPart@17024400 : Codeunit 50019);
+    BEGIN
+      MainDocumentPart.SetMainDocumentPart(DotNetWordprocessingDocument.MainDocumentPart);
+    END;
+
+    PROCEDURE SetWordProcessingDocument@17024400(NewWordprocessingDocument@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.WordprocessingDocument");
+    BEGIN
+      DotNetWordprocessingDocument := NewWordprocessingDocument;
+    END;
+
+    PROCEDURE GetWordProcessingDocument@17024403(VAR CurrentWordprocessingDocument@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.WordprocessingDocument");
+    BEGIN
+      CurrentWordprocessingDocument := DotNetWordprocessingDocument;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50019.TXT
+++ b/BaseApp/COD50019.TXT
@@ -1,0 +1,126 @@
+OBJECT Codeunit 50019 DotNet_Word.MainDocumentPart
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetMainDocumentPart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.MainDocumentPart";
+      OpenXmlDotNetHelper@17024401 : Codeunit 50067;
+
+    PROCEDURE SetMainDocumentPart@17024411(NewMainDocumentPart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.MainDocumentPart");
+    BEGIN
+      DotNetMainDocumentPart := NewMainDocumentPart;
+    END;
+
+    PROCEDURE GetMainDocumentPart@17024400(VAR CurrentMainDocumentPart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.MainDocumentPart");
+    BEGIN
+      CurrentMainDocumentPart := DotNetMainDocumentPart;
+    END;
+
+    [External]
+    PROCEDURE AddHyperlinkRelationship@17024403(Url@17024400 : Text;IsExternal@17024401 : Boolean;VAR CreatedHyperlinkRelationship@17024402 : Codeunit 50034);
+    VAR
+      DotNetUri@17024403 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Uri";
+    BEGIN
+      CreatedHyperlinkRelationship.SetHyperlinkRelationship(DotNetMainDocumentPart.AddHyperlinkRelationship(DotNetUri.Uri(Url), IsExternal));
+    END;
+
+    [External]
+    PROCEDURE AddNumberingDefinitionsPart@17024409(VAR CreatedNumberingDefinitionsPart@17024402 : Codeunit 50070);
+    VAR
+      DotNetNumberingDefinitionsPart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.NumberingDefinitionsPart";
+      DotNetObject@17024405 : DotNet "'mscorlib'.System.Object";
+    BEGIN
+      //Normally is should have been something as simple as:
+      //DotNetNumberingDefinitionsPart := DotNetMainDocumentPart.AddNewPart<NumberingDefinitionsPart>();
+      //But since NAV have no such thing as generics support, I need to fallback to reflection calls:
+      OpenXmlDotNetHelper.AddPartGeneric(DotNetMainDocumentPart, GETDOTNETTYPE(DotNetNumberingDefinitionsPart), DotNetObject);
+      CreatedNumberingDefinitionsPart.SetNumberingDefinitionsPart(DotNetObject);
+    END;
+
+    [External]
+    PROCEDURE HasNumberingDefinitionsPart@17024412() : Boolean;
+    BEGIN
+      EXIT(NOT ISNULL(DotNetMainDocumentPart.NumberingDefinitionsPart));
+    END;
+
+    [External]
+    PROCEDURE GetNumberingDefinitionsPart@17024414(VAR WordNumberingDefinitionPart@17024400 : Codeunit 50070);
+    BEGIN
+      WordNumberingDefinitionPart.SetNumberingDefinitionsPart(DotNetMainDocumentPart.NumberingDefinitionsPart);
+    END;
+
+    [External]
+    PROCEDURE AddStyleDefinitionsPart@17024404(VAR CreatedStyleDefinitionsPart@17024402 : Codeunit 50041);
+    VAR
+      DotNetStyleDefinitionsPart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.StyleDefinitionsPart";
+      DotNetObject@17024405 : DotNet "'mscorlib'.System.Object";
+    BEGIN
+      //Normally is should have been something as simple as:
+      //DotNetStyleDefinitionsPart := DotNetMainDocumentPart.AddNewPart<StyleDefinitionsPart>();
+      //But since NAV have no such thing as generics support, I need to fallback to reflection calls:
+      OpenXmlDotNetHelper.AddPartGeneric(DotNetMainDocumentPart, GETDOTNETTYPE(DotNetStyleDefinitionsPart), DotNetObject);
+      CreatedStyleDefinitionsPart.SetStyleDefinitionsPart(DotNetObject);
+    END;
+
+    [External]
+    PROCEDURE HasStyleDefinitionsPart@17024405() : Boolean;
+    BEGIN
+      EXIT(NOT ISNULL(DotNetMainDocumentPart.StyleDefinitionsPart));
+    END;
+
+    [External]
+    PROCEDURE GetStyleDefinitionsPart@17024408(VAR WordStyleDefinitionPart@17024400 : Codeunit 50041);
+    BEGIN
+      WordStyleDefinitionPart.SetStyleDefinitionsPart(DotNetMainDocumentPart.StyleDefinitionsPart);
+    END;
+
+    [External]
+    PROCEDURE AddImagePart@17024406(ImagePartType@17024400 : 'Bmp,Gif,Png,Tiff,Icon,Pcx,Jpeg,Emf,Wmf';VAR CreatedImagePart@17024402 : Codeunit 50042);
+    VAR
+      DotNetImagePartType@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.ImagePartType";
+    BEGIN
+      DotNetImagePartType := DotNetImagePartType.Parse(GETDOTNETTYPE(DotNetImagePartType), FORMAT(ImagePartType, 0));
+      CreatedImagePart.SetImagePart(DotNetMainDocumentPart.AddImagePart(DotNetImagePartType));
+    END;
+
+    [External]
+    PROCEDURE GetIdOfImagePart@17024407(VAR ImagePart@17024402 : Codeunit 50042) : Text;
+    VAR
+      DotNetImagePart@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.ImagePart";
+    BEGIN
+      ImagePart.GetImagePart(DotNetImagePart);
+      EXIT(DotNetMainDocumentPart.GetIdOfPart(DotNetImagePart));
+    END;
+
+    [External]
+    PROCEDURE SetDocument@17024401(VAR WordDocument@17024400 : Codeunit 50020);
+    VAR
+      DotNetDocument@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Document";
+    BEGIN
+      WordDocument.GetDocument(DotNetDocument);
+      DotNetMainDocumentPart.Document := DotNetDocument;
+    END;
+
+    [External]
+    PROCEDURE GetDocument@17024402(VAR DotNetWordDocument@17024400 : Codeunit 50020);
+    BEGIN
+      DotNetWordDocument.SetDocument(DotNetMainDocumentPart.Document);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50020.TXT
+++ b/BaseApp/COD50020.TXT
@@ -1,0 +1,75 @@
+OBJECT Codeunit 50020 DotNet_Word.Document
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetDocument@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Document";
+
+    [External]
+    PROCEDURE Create@17024402();
+    BEGIN
+      DotNetDocument := DotNetDocument.Document;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024409(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetDocument := DotNetDocument.Document(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024404() : Text;
+    BEGIN
+      EXIT(DotNetDocument.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024406() : Text;
+    BEGIN
+      EXIT(DotNetDocument.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetBody@17024401(VAR WordBody@17024400 : Codeunit 50021);
+    VAR
+      DotNetBody@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Body";
+    BEGIN
+      WordBody.GetBody(DotNetBody);
+      DotNetDocument.Body := DotNetBody;
+    END;
+
+    [External]
+    PROCEDURE GetBody@17024403(VAR WordBody@17024400 : Codeunit 50021);
+    VAR
+      DotNetBody@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Body";
+    BEGIN
+      WordBody.SetBody(DotNetDocument.Body);
+    END;
+
+    PROCEDURE SetDocument@17024411(NewDocument@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Document");
+    BEGIN
+      DotNetDocument := NewDocument;
+    END;
+
+    PROCEDURE GetDocument@17024400(VAR CurrentDocument@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Document");
+    BEGIN
+      CurrentDocument := DotNetDocument;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50021.TXT
+++ b/BaseApp/COD50021.TXT
@@ -1,0 +1,104 @@
+OBJECT Codeunit 50021 DotNet_Word.Body
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetBody@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Body";
+      OpenXmlDotNetHelper@17024401 : Codeunit 50067;
+
+    [External]
+    PROCEDURE Create@17024401();
+    BEGIN
+      DotNetBody := DotNetBody.Body;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024409(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetBody := DotNetBody.Body(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024405() : Text;
+    BEGIN
+      EXIT(DotNetBody.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024406() : Text;
+    BEGIN
+      EXIT(DotNetBody.InnerText);
+    END;
+
+    [External]
+    PROCEDURE AppendParagraph@17024403(VAR WordParagraph@17024400 : Codeunit 50022);
+    VAR
+      DotNetParagraph@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Paragraph";
+    BEGIN
+      WordParagraph.GetParagraph(DotNetParagraph);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetBody, DotNetParagraph);
+    END;
+
+    [External]
+    PROCEDURE AppendTable@17024402(VAR WordTable@17024400 : Codeunit 50027);
+    VAR
+      DotNetTable@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Table";
+      DotNetArray@17024402 : DotNet "'mscorlib'.System.Array";
+    BEGIN
+      WordTable.GetTable(DotNetTable);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetBody, DotNetTable);
+    END;
+
+    [External]
+    PROCEDURE GetTableEnumerator@17024404(VAR WordTableEnumerator@17024400 : Codeunit 50064);
+    VAR
+      EnumeratorHelper@17024401 : Codeunit 50067;
+      DotNetTable@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Table";
+      DotNetEnumerator@17024403 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+    BEGIN
+      //We need this to deal with .NET Generics:
+      EnumeratorHelper.GetEnumeratorOfTypeGeneric(DotNetBody.Elements, GETDOTNETTYPE(DotNetTable), DotNetEnumerator);
+      WordTableEnumerator.SetEnumerator(DotNetEnumerator);
+    END;
+
+    [External]
+    PROCEDURE GetParagraphEnumerator@17024408(VAR WordParagraphEnumerator@17024400 : Codeunit 50062);
+    VAR
+      EnumeratorHelper@17024401 : Codeunit 50067;
+      DotNetParagraph@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Paragraph";
+      DotNetEnumerator@17024403 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+    BEGIN
+      //We need this to deal with .NET Generics:
+      EnumeratorHelper.GetEnumeratorOfTypeGeneric(DotNetBody.Elements, GETDOTNETTYPE(DotNetParagraph), DotNetEnumerator);
+      WordParagraphEnumerator.SetEnumerator(DotNetEnumerator);
+    END;
+
+    PROCEDURE SetBody@17024411(NewDotNetBody@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Body");
+    BEGIN
+      DotNetBody := NewDotNetBody;
+    END;
+
+    PROCEDURE GetBody@17024400(VAR CurrentDotNetBody@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Body");
+    BEGIN
+      CurrentDotNetBody := DotNetBody;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50022.TXT
+++ b/BaseApp/COD50022.TXT
@@ -1,0 +1,101 @@
+OBJECT Codeunit 50022 DotNet_Word.Paragraph
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetParagraph@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Paragraph";
+      OpenXmlDotNetHelper@17024401 : Codeunit 50067;
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetParagraph := DotNetParagraph.Paragraph;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024409(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetParagraph := DotNetParagraph.Paragraph(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024405() : Text;
+    BEGIN
+      EXIT(DotNetParagraph.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024406() : Text;
+    BEGIN
+      EXIT(DotNetParagraph.InnerText);
+    END;
+
+    [External]
+    PROCEDURE AppendRun@17024401(VAR WordRun@17024400 : Codeunit 50023);
+    VAR
+      DotNetRun@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Run";
+    BEGIN
+      WordRun.GetRun(DotNetRun);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetParagraph, DotNetRun);
+    END;
+
+    [External]
+    PROCEDURE AppendHyperlink@17024404(VAR WordHyperlink@17024400 : Codeunit 50035);
+    VAR
+      DotNetHyperlink@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Hyperlink";
+    BEGIN
+      WordHyperlink.GetHyperlink(DotNetHyperlink);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetParagraph, DotNetHyperlink);
+    END;
+
+    [External]
+    PROCEDURE AppendProperties@17024402(VAR WordParagraphProperties@17024400 : Codeunit 50026);
+    VAR
+      DotNetParagraphProperties@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.ParagraphProperties";
+    BEGIN
+      WordParagraphProperties.GetParagraphProperties(DotNetParagraphProperties);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetParagraph, DotNetParagraphProperties);
+    END;
+
+    [External]
+    PROCEDURE GetRunEnumerator@17024408(VAR WordRunEnumerator@17024400 : Codeunit 50063);
+    VAR
+      EnumeratorHelper@17024401 : Codeunit 50067;
+      DotNetRun@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Run";
+      DotNetEnumerator@17024403 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+    BEGIN
+      //We need this to deal with .NET Generics:
+      EnumeratorHelper.GetEnumeratorOfTypeGeneric(DotNetParagraph.Elements, GETDOTNETTYPE(DotNetRun), DotNetEnumerator);
+      WordRunEnumerator.SetEnumerator(DotNetEnumerator);
+    END;
+
+    PROCEDURE SetParagraph@17024411(NewDotNetParagraph@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Paragraph");
+    BEGIN
+      DotNetParagraph := NewDotNetParagraph;
+    END;
+
+    PROCEDURE GetParagraph@17024400(VAR CurrentDotNetParagraph@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Paragraph");
+    BEGIN
+      CurrentDotNetParagraph := DotNetParagraph;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50023.TXT
+++ b/BaseApp/COD50023.TXT
@@ -1,0 +1,103 @@
+OBJECT Codeunit 50023 DotNet_Word.Run
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetRun@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Run";
+      OpenXmlDotNetHelper@17024401 : Codeunit 50067;
+
+    [External]
+    PROCEDURE Create@17024403();
+    VAR
+      DotNetXmlElem@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Underline";
+    BEGIN
+      DotNetRun := DotNetRun.Run;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024409(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetRun := DotNetRun.Run(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024405() : Text;
+    BEGIN
+      EXIT(DotNetRun.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024406() : Text;
+    BEGIN
+      EXIT(DotNetRun.InnerText);
+    END;
+
+    [External]
+    PROCEDURE AppendText@17024401(VAR WordText@17024400 : Codeunit 50024);
+    VAR
+      DotNetText@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Text";
+    BEGIN
+      WordText.GetTextObject(DotNetText);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetRun, DotNetText);
+    END;
+
+    [External]
+    PROCEDURE AppendDrawing@17024404(VAR WordDrawing@17024400 : Codeunit 50043);
+    VAR
+      DotNetDrawing@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Drawing";
+    BEGIN
+      WordDrawing.GetDrawing(DotNetDrawing);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetRun, DotNetDrawing);
+    END;
+
+    [External]
+    PROCEDURE AppendProperties@17024402(VAR WordRunProperties@17024400 : Codeunit 50025);
+    VAR
+      DotNetRunProperties@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.RunProperties";
+    BEGIN
+      WordRunProperties.GetRunProperties(DotNetRunProperties);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetRun, DotNetRunProperties);
+    END;
+
+    [External]
+    PROCEDURE GetTextEnumerator@17024408(VAR WordTextEnumerator@17024400 : Codeunit 50076);
+    VAR
+      EnumeratorHelper@17024401 : Codeunit 50067;
+      DotNetText@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Text";
+      DotNetEnumerator@17024403 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+    BEGIN
+      //We need this to deal with .NET Generics:
+      EnumeratorHelper.GetEnumeratorOfTypeGeneric(DotNetRun.Elements, GETDOTNETTYPE(DotNetText), DotNetEnumerator);
+      WordTextEnumerator.SetEnumerator(DotNetEnumerator);
+    END;
+
+    PROCEDURE SetRun@17024411(NewDotNetRun@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Run");
+    BEGIN
+      DotNetRun := NewDotNetRun;
+    END;
+
+    PROCEDURE GetRun@17024400(VAR CurrentDotNetRun@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Run");
+    BEGIN
+      CurrentDotNetRun := DotNetRun;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50024.TXT
+++ b/BaseApp/COD50024.TXT
@@ -1,0 +1,91 @@
+OBJECT Codeunit 50024 DotNet_Word.Text
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetText@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Text";
+
+    [External]
+    PROCEDURE Create@17024403();
+    VAR
+      DotNetType@17024401 : DotNet "'mscorlib'.System.Type";
+      DotNetObject@17024404 : DotNet "'mscorlib'.System.Object";
+      DotNetTypeArray@17024402 : DotNet "'mscorlib'.System.Array";
+      DotNetParamsArray@17024403 : DotNet "'mscorlib'.System.Array";
+    BEGIN
+      //So normally it should be a simple call like that:
+      //DotNetText := DotNetText.Text();
+      //but constructor name equals to property name (both "Text") and in NAV we have no way to handle it
+      //so I need to use some tricks here
+      //basically I get constructor using reflection and then call it
+      DotNetType := GETDOTNETTYPE(DotNetText);
+      DotNetTypeArray := DotNetTypeArray.CreateInstance(GETDOTNETTYPE(DotNetType), 0);
+      DotNetParamsArray := DotNetParamsArray.CreateInstance(GETDOTNETTYPE(DotNetObject), 0);
+      DotNetText := DotNetType.GetConstructor(DotNetTypeArray).Invoke(DotNetParamsArray);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024404() : Text;
+    BEGIN
+      EXIT(DotNetText.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024401() : Text;
+    BEGIN
+      EXIT(DotNetText.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetText@17024405(NewText@17024400 : Text);
+    BEGIN
+      DotNetText.Text := NewText;
+    END;
+
+    [External]
+    PROCEDURE GetText@17024406() : Text;
+    BEGIN
+      EXIT(DotNetText.Text);
+    END;
+
+    [External]
+    PROCEDURE SetSpacePreserveOption@17024402(PreserveSpace@17024400 : Boolean);
+    VAR
+      DotNetSpaceProcessingModeValues@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.SpaceProcessingModeValues";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+      DotNetEnumValue@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.EnumValue`1";
+    BEGIN
+      IF PreserveSpace THEN
+        OpenXmlDotNetHelper.CreateEnumValueGeneric(GETDOTNETTYPE(DotNetSpaceProcessingModeValues), 1, DotNetEnumValue)
+      ELSE
+        OpenXmlDotNetHelper.CreateEnumValueGeneric(GETDOTNETTYPE(DotNetSpaceProcessingModeValues), 0, DotNetEnumValue);
+      DotNetText.Space := DotNetEnumValue;
+    END;
+
+    PROCEDURE SetTextObject@17024411(NewDotNetText@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Text");
+    BEGIN
+      DotNetText := NewDotNetText;
+    END;
+
+    PROCEDURE GetTextObject@17024400(VAR CurrentDotNetText@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Text");
+    BEGIN
+      CurrentDotNetText := DotNetText;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50025.TXT
+++ b/BaseApp/COD50025.TXT
@@ -1,0 +1,127 @@
+OBJECT Codeunit 50025 DotNet_Word.RunProperties
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetRunProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.RunProperties";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetRunProperties := DotNetRunProperties.RunProperties;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetRunProperties := DotNetRunProperties.RunProperties(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024407() : Text;
+    BEGIN
+      EXIT(DotNetRunProperties.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetRunProperties.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetBold@17024405(Bold@17024401 : Boolean);
+    VAR
+      DotNetBold@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Bold";
+      DotNetBoldNull@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Bold";
+    BEGIN
+      DotNetBold := DotNetBold.Bold;
+      IF Bold THEN
+        DotNetRunProperties.Bold := DotNetBold
+      ELSE
+        DotNetRunProperties.Bold := DotNetBoldNull;
+    END;
+
+    [External]
+    PROCEDURE SetItalic@17024409(Italic@17024401 : Boolean);
+    VAR
+      DotNetItalic@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Italic";
+      DotNetItalicNull@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Italic";
+    BEGIN
+      DotNetItalic := DotNetItalic.Italic;
+      IF Italic THEN
+        DotNetRunProperties.Italic := DotNetItalic
+      ELSE
+        DotNetRunProperties.Italic := DotNetItalicNull;
+    END;
+
+    [External]
+    PROCEDURE SetUnderline@17024401(Underline@17024401 : Boolean);
+    VAR
+      DotNetUnderline@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Underline";
+      DotNetUnderlineNull@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Underline";
+    BEGIN
+      DotNetUnderline := DotNetUnderline.Underline;
+      IF Underline THEN
+        DotNetRunProperties.Underline := DotNetUnderline
+      ELSE
+        DotNetRunProperties.Underline := DotNetUnderlineNull;
+    END;
+
+    [External]
+    PROCEDURE SetFontSize@17024406(NewFontSize@17024401 : Text);
+    VAR
+      DotNetFontSize@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.FontSize";
+      DotNetStringValue@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetFontSize := DotNetFontSize.FontSize;
+      DotNetFontSize.Val := DotNetStringValue.StringValue(NewFontSize);
+    END;
+
+    [External]
+    PROCEDURE SetColor@17024404(VAR WordColor@17024401 : Codeunit 50036);
+    VAR
+      DotNetColor@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Color";
+    BEGIN
+      WordColor.GetColor(DotNetColor);
+      DotNetRunProperties.Color := DotNetColor;
+    END;
+
+    [External]
+    PROCEDURE SetRunStyle@17024402(StyleName@17024401 : Text);
+    VAR
+      DotNetRunStyle@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.RunStyle";
+      DotNetStringValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetRunStyle := DotNetRunStyle.RunStyle;
+      DotNetRunStyle.Val := DotNetStringValue.StringValue(StyleName);
+      DotNetRunProperties.RunStyle := DotNetRunStyle;
+    END;
+
+    PROCEDURE SetRunProperties@17024411(NewDotNetRunProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.RunProperties");
+    BEGIN
+      DotNetRunProperties := NewDotNetRunProperties;
+    END;
+
+    PROCEDURE GetRunProperties@17024400(VAR CurrentDotNetRunProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.RunProperties");
+    BEGIN
+      CurrentDotNetRunProperties := DotNetRunProperties;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50026.TXT
+++ b/BaseApp/COD50026.TXT
@@ -1,0 +1,115 @@
+OBJECT Codeunit 50026 DotNet_Word.ParagraphProp
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetParagraphProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.ParagraphProperties";
+
+    [External]
+    PROCEDURE Create@17024403();
+    VAR
+      DotNetXmlElem@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Underline";
+    BEGIN
+      DotNetParagraphProperties := DotNetParagraphProperties.ParagraphProperties;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024401 : Text);
+    VAR
+      DotNetXmlElem@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Underline";
+    BEGIN
+      DotNetParagraphProperties := DotNetParagraphProperties.ParagraphProperties(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetParagraphProperties.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetParagraphProperties.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetJustification@17024404(Justification@17024401 : 'Left,Start,Center,Right,End,Both,MediumKashida,Distribute,NumTab,HighKashida,LowKashida,ThaiDistribute');
+    VAR
+      DotNetJustification@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Justification";
+      DotNetJustificationValues@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.JustificationValues";
+      DotNetEnumValue@17024404 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.EnumValue`1";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      DotNetJustification := DotNetJustification.Justification;
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.CreateEnumValueGeneric(GETDOTNETTYPE(DotNetJustificationValues), Justification, DotNetEnumValue);
+      DotNetJustification.Val := DotNetEnumValue;
+      DotNetParagraphProperties.Justification := DotNetJustification;
+    END;
+
+    [External]
+    PROCEDURE SetSpacingBetweenLines@17024401(VAR WordSpacingBetweenLines@17024401 : Codeunit 50030);
+    VAR
+      DotNetSpacingBetweenLines@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.SpacingBetweenLines";
+    BEGIN
+      WordSpacingBetweenLines.GetSpacingBetweenLines(DotNetSpacingBetweenLines);
+      DotNetParagraphProperties.SpacingBetweenLines := DotNetSpacingBetweenLines;
+    END;
+
+    [External]
+    PROCEDURE SetIndentation@17024406(VAR WordIndentation@17024401 : Codeunit 50031);
+    VAR
+      DotNetIndentation@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Indentation";
+    BEGIN
+      WordIndentation.GetIndentation(DotNetIndentation);
+      DotNetParagraphProperties.Indentation := DotNetIndentation;
+    END;
+
+    [External]
+    PROCEDURE SetNumberingProperties@17024409(VAR WordNumberingProperties@17024401 : Codeunit 50032);
+    VAR
+      DotNetNumberingProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.NumberingProperties";
+    BEGIN
+      WordNumberingProperties.GetNumberingProperties(DotNetNumberingProperties);
+      DotNetParagraphProperties.NumberingProperties := DotNetNumberingProperties;
+    END;
+
+    [External]
+    PROCEDURE SetParagraphStyleId@17024407(NewParagraphStyleId@17024400 : Text);
+    VAR
+      DotNetParagraphStyleId@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.ParagraphStyleId";
+      DotNetStringValue@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetParagraphStyleId := DotNetParagraphStyleId.ParagraphStyleId;
+      DotNetParagraphStyleId.Val := DotNetStringValue.FromString(NewParagraphStyleId);
+      DotNetParagraphProperties.ParagraphStyleId := DotNetParagraphStyleId;
+    END;
+
+    PROCEDURE SetParagraphProperties@17024411(NewDotNetParagraphProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.ParagraphProperties");
+    BEGIN
+      DotNetParagraphProperties := NewDotNetParagraphProperties;
+    END;
+
+    PROCEDURE GetParagraphProperties@17024400(VAR CurrentDotNetParagraphProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.ParagraphProperties");
+    BEGIN
+      CurrentDotNetParagraphProperties := DotNetParagraphProperties;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50027.TXT
+++ b/BaseApp/COD50027.TXT
@@ -1,0 +1,83 @@
+OBJECT Codeunit 50027 DotNet_Word.Table
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetTable@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Table";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetTable := DotNetTable.Table;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024401 : Text);
+    VAR
+      DotNetXmlElem@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Underline";
+    BEGIN
+      DotNetTable := DotNetTable.Table(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetTable.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetTable.InnerText);
+    END;
+
+    [External]
+    PROCEDURE AppendRow@17024401(WordTableRow@17024400 : Codeunit 50028);
+    VAR
+      DotNetTableRow@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.TableRow";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      WordTableRow.GetTableRow(DotNetTableRow);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetTable, DotNetTableRow);
+    END;
+
+    [External]
+    PROCEDURE GetTableRowEnumerator@17024404(VAR WordTableRowEnumerator@17024400 : Codeunit 50065);
+    VAR
+      EnumeratorHelper@17024401 : Codeunit 50067;
+      DotNetTableRow@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.TableRow";
+      DotNetEnumerator@17024403 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+    BEGIN
+      //We need this to deal with .NET Generics:
+      EnumeratorHelper.GetEnumeratorOfTypeGeneric(DotNetTable.Elements, GETDOTNETTYPE(DotNetTableRow), DotNetEnumerator);
+      WordTableRowEnumerator.SetEnumerator(DotNetEnumerator);
+    END;
+
+    PROCEDURE SetTable@17024411(NewDotNetTable@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Table");
+    BEGIN
+      DotNetTable := NewDotNetTable;
+    END;
+
+    PROCEDURE GetTable@17024400(VAR CurrentDotNetTable@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Table");
+    BEGIN
+      CurrentDotNetTable := DotNetTable;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50028.TXT
+++ b/BaseApp/COD50028.TXT
@@ -1,0 +1,83 @@
+OBJECT Codeunit 50028 DotNet_Word.TableRow
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetTableRow@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.TableRow";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetTableRow := DotNetTableRow.TableRow;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024401 : Text);
+    VAR
+      DotNetXmlElem@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Underline";
+    BEGIN
+      DotNetTableRow := DotNetTableRow.TableRow(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetTableRow.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetTableRow.InnerText);
+    END;
+
+    [External]
+    PROCEDURE AppendCell@17024401(WordTableCell@17024400 : Codeunit 50029);
+    VAR
+      DotNetTableCell@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.TableCell";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      WordTableCell.GetTableCell(DotNetTableCell);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetTableRow, DotNetTableCell);
+    END;
+
+    [External]
+    PROCEDURE GetTableCellEnumerator@17024404(VAR WordTableCellEnumerator@17024400 : Codeunit 50066);
+    VAR
+      EnumeratorHelper@17024401 : Codeunit 50067;
+      DotNetTableCell@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.TableCell";
+      DotNetEnumerator@17024403 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+    BEGIN
+      //We need this to deal with .NET Generics:
+      EnumeratorHelper.GetEnumeratorOfTypeGeneric(DotNetTableRow.Elements, GETDOTNETTYPE(DotNetTableCell), DotNetEnumerator);
+      WordTableCellEnumerator.SetEnumerator(DotNetEnumerator);
+    END;
+
+    PROCEDURE SetTableRow@17024411(NewDotNetTableRow@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.TableRow");
+    BEGIN
+      DotNetTableRow := NewDotNetTableRow;
+    END;
+
+    PROCEDURE GetTableRow@17024400(VAR CurrentDotNetTableRow@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.TableRow");
+    BEGIN
+      CurrentDotNetTableRow := DotNetTableRow;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50029.TXT
+++ b/BaseApp/COD50029.TXT
@@ -1,0 +1,83 @@
+OBJECT Codeunit 50029 DotNet_Word.TableCell
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetTableCell@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.TableCell";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetTableCell := DotNetTableCell.TableCell;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024404(OuterXml@17024401 : Text);
+    VAR
+      DotNetXmlElem@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Underline";
+    BEGIN
+      DotNetTableCell := DotNetTableCell.TableCell(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetTableCell.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetTableCell.InnerText);
+    END;
+
+    [External]
+    PROCEDURE AppendParagraph@17024401(WordParagraph@17024400 : Codeunit 50022);
+    VAR
+      DotNetParagraph@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Paragraph";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      WordParagraph.GetParagraph(DotNetParagraph);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetTableCell, DotNetParagraph);
+    END;
+
+    [External]
+    PROCEDURE GetParagraphEnumerator@17024408(VAR WordParagraphEnumerator@17024400 : Codeunit 50062);
+    VAR
+      EnumeratorHelper@17024401 : Codeunit 50067;
+      DotNetParagraph@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Paragraph";
+      DotNetEnumerator@17024403 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+    BEGIN
+      //We need this to deal with .NET Generics:
+      EnumeratorHelper.GetEnumeratorOfTypeGeneric(DotNetTableCell.Elements, GETDOTNETTYPE(DotNetParagraph), DotNetEnumerator);
+      WordParagraphEnumerator.SetEnumerator(DotNetParagraph);
+    END;
+
+    PROCEDURE SetTableCell@17024411(NewDotNetTableCell@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.TableCell");
+    BEGIN
+      DotNetTableCell := NewDotNetTableCell;
+    END;
+
+    PROCEDURE GetTableCell@17024400(VAR CurrentDotNetTableCell@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.TableCell");
+    BEGIN
+      CurrentDotNetTableCell := DotNetTableCell;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50030.TXT
+++ b/BaseApp/COD50030.TXT
@@ -1,0 +1,62 @@
+OBJECT Codeunit 50030 DotNet_Word.SpacingBetweenLine
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetSpacingBetweenLines@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.SpacingBetweenLines";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetSpacingBetweenLines := DotNetSpacingBetweenLines.SpacingBetweenLines;
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetSpacingBetweenLines.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetSpacingBetweenLines.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetAfter@17024401(NewAfterValue@17024400 : Text);
+    VAR
+      DotNetStringValue@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetStringValue := DotNetStringValue.StringValue;
+      DotNetStringValue.Value := NewAfterValue;
+      DotNetSpacingBetweenLines.After := DotNetStringValue;
+    END;
+
+    PROCEDURE SetSpacingBetweenLines@17024411(NewDotNetSpacingBetweenLines@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.SpacingBetweenLines");
+    BEGIN
+      DotNetSpacingBetweenLines := NewDotNetSpacingBetweenLines;
+    END;
+
+    PROCEDURE GetSpacingBetweenLines@17024400(VAR CurrentDotNetSpacingBetweenLines@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.SpacingBetweenLines");
+    BEGIN
+      CurrentDotNetSpacingBetweenLines := DotNetSpacingBetweenLines;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50031.TXT
+++ b/BaseApp/COD50031.TXT
@@ -1,0 +1,72 @@
+OBJECT Codeunit 50031 DotNet_Word.Indentation
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetIndentation@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Indentation";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetIndentation := DotNetIndentation.Indentation;
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetIndentation.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetIndentation.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetLeft@17024401(NewLeftValue@17024400 : Text);
+    VAR
+      DotNetStringValue@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetStringValue := DotNetStringValue.StringValue;
+      DotNetStringValue.Value := NewLeftValue;
+      DotNetIndentation.Left := DotNetStringValue;
+    END;
+
+    [External]
+    PROCEDURE SetHanging@17024407(NewHangingValue@17024400 : Text);
+    VAR
+      DotNetStringValue@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetStringValue := DotNetStringValue.StringValue;
+      DotNetStringValue.Value := NewHangingValue;
+      DotNetIndentation.Hanging := DotNetStringValue;
+    END;
+
+    PROCEDURE SetIndentation@17024411(NewDotNetIndentation@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Indentation");
+    BEGIN
+      DotNetIndentation := NewDotNetIndentation;
+    END;
+
+    PROCEDURE GetIndentation@17024400(VAR CurrentDotNetIndentation@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Indentation");
+    BEGIN
+      CurrentDotNetIndentation := DotNetIndentation;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50032.TXT
+++ b/BaseApp/COD50032.TXT
@@ -1,0 +1,82 @@
+OBJECT Codeunit 50032 DotNet_Word.NumberingPropertie
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetNumberingProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.NumberingProperties";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetNumberingProperties := DotNetNumberingProperties.NumberingProperties;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024401 : Text);
+    VAR
+      DotNetXmlElem@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Underline";
+    BEGIN
+      DotNetNumberingProperties := DotNetNumberingProperties.NumberingProperties(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetNumberingProperties.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetNumberingProperties.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetNumberingLevelReference@17024401(NewNumberingLevelReference@17024400 : Integer);
+    VAR
+      DotNetInt32Value@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Int32Value";
+      DotNetNumberingLevelReference@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.NumberingLevelReference";
+    BEGIN
+      DotNetNumberingLevelReference := DotNetNumberingLevelReference.NumberingLevelReference;
+      DotNetNumberingLevelReference.Val := DotNetInt32Value.FromInt32(NewNumberingLevelReference);
+      DotNetNumberingProperties.NumberingLevelReference := DotNetNumberingLevelReference;
+    END;
+
+    [External]
+    PROCEDURE SetNumberingId@17024407(NewNumberingId@17024400 : Integer);
+    VAR
+      DotNetInt32Value@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Int32Value";
+      DotNetNumberingId@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.NumberingId";
+    BEGIN
+      DotNetNumberingId := DotNetNumberingId.NumberingId;
+      DotNetNumberingId.Val := DotNetInt32Value.FromInt32(NewNumberingId);
+      DotNetNumberingProperties.NumberingId := DotNetNumberingId;
+    END;
+
+    PROCEDURE SetNumberingProperties@17024411(NewDotNetNumberingProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.NumberingProperties");
+    BEGIN
+      DotNetNumberingProperties := NewDotNetNumberingProperties;
+    END;
+
+    PROCEDURE GetNumberingProperties@17024400(VAR CurrentDotNetNumberingProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.NumberingProperties");
+    BEGIN
+      CurrentDotNetNumberingProperties := DotNetNumberingProperties;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50033.TXT
+++ b/BaseApp/COD50033.TXT
@@ -1,0 +1,63 @@
+OBJECT Codeunit 50033 DotNet_Word.ProofError
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetProofError@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.ProofError";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetProofError := DotNetProofError.ProofError;
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetProofError.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetProofError.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetType@17024401(NewProofingErrorType@17024400 : 'SpellStart,SpellEnd,GrammarStart,GrammarEnd');
+    VAR
+      DotNetProofingErrorValues@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.ProofingErrorValues";
+      DotNetEnumValue@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.EnumValue`1";
+      OpenXmlDotNetHelper@17024401 : Codeunit 50067;
+    BEGIN
+      OpenXmlDotNetHelper.CreateEnumValueGeneric(GETDOTNETTYPE(DotNetProofingErrorValues), NewProofingErrorType, DotNetEnumValue);
+      DotNetProofError.Type := DotNetEnumValue;
+    END;
+
+    PROCEDURE SetProofError@17024411(NewDotNetProofError@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.ProofError");
+    BEGIN
+      DotNetProofError := NewDotNetProofError;
+    END;
+
+    PROCEDURE GetProofError@17024400(VAR CurrentDotNetProofError@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.ProofError");
+    BEGIN
+      CurrentDotNetProofError := DotNetProofError;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50034.TXT
+++ b/BaseApp/COD50034.TXT
@@ -1,0 +1,40 @@
+OBJECT Codeunit 50034 DotNet_Word.HyperlinkRelations
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetHyperlinkRelationship@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.HyperlinkRelationship";
+
+    [External]
+    PROCEDURE GetId@17024401() : Text;
+    BEGIN
+      EXIT(DotNetHyperlinkRelationship.Id);
+    END;
+
+    PROCEDURE SetHyperlinkRelationship@17024411(NewDotNetHyperlinkRelationship@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.HyperlinkRelationship");
+    BEGIN
+      DotNetHyperlinkRelationship := NewDotNetHyperlinkRelationship;
+    END;
+
+    PROCEDURE GetHyperlinkRelationship@17024400(VAR CurrentDotNetHyperlinkRelationship@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.HyperlinkRelationship");
+    BEGIN
+      CurrentDotNetHyperlinkRelationship := DotNetHyperlinkRelationship;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50035.TXT
+++ b/BaseApp/COD50035.TXT
@@ -1,0 +1,97 @@
+OBJECT Codeunit 50035 DotNet_Word.Hyperlink
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetHyperlink@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Hyperlink";
+      OpenXmlDotNetHelper@17024401 : Codeunit 50067;
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetHyperlink := DotNetHyperlink.Hyperlink;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024401 : Text);
+    VAR
+      DotNetXmlElem@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Underline";
+    BEGIN
+      DotNetHyperlink := DotNetHyperlink.Hyperlink(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024404() : Text;
+    BEGIN
+      EXIT(DotNetHyperlink.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetHyperlink.InnerText);
+    END;
+
+    [External]
+    PROCEDURE AppendRun@17024401(VAR WordRun@17024400 : Codeunit 50023);
+    VAR
+      DotNetRun@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Run";
+    BEGIN
+      WordRun.GetRun(DotNetRun);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetHyperlink, DotNetRun);
+    END;
+
+    [External]
+    PROCEDURE AppendProofError@17024402(VAR WordProofError@17024400 : Codeunit 50033);
+    VAR
+      DotNetProofError@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.ProofError";
+    BEGIN
+      WordProofError.GetProofError(DotNetProofError);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetHyperlink, DotNetProofError);
+    END;
+
+    [External]
+    PROCEDURE SetId@17024406(NewId@17024400 : Text);
+    VAR
+      DotNetStringValue@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetHyperlink.Id := DotNetStringValue.StringValue(NewId);
+    END;
+
+    [External]
+    PROCEDURE SetHistory@17024405(NewHistory@17024400 : Boolean);
+    VAR
+      DotNetOnOffValue@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.OnOffValue";
+    BEGIN
+      DotNetHyperlink.History := DotNetOnOffValue.FromBoolean(NewHistory);
+    END;
+
+    PROCEDURE SetHyperlink@17024411(NewDotNetHyperlink@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Hyperlink");
+    BEGIN
+      DotNetHyperlink := NewDotNetHyperlink;
+    END;
+
+    PROCEDURE GetHyperlink@17024400(VAR CurrentDotNetHyperlink@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Hyperlink");
+    BEGIN
+      CurrentDotNetHyperlink := DotNetHyperlink;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50036.TXT
+++ b/BaseApp/COD50036.TXT
@@ -1,0 +1,72 @@
+OBJECT Codeunit 50036 DotNet_Word.Color
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetColor@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Color";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetColor := DotNetColor.Color;
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetColor.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetColor.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetColorValue@17024406(NewColorArgb@17024400 : Text);
+    VAR
+      DotNetStringValue@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetColor.Val := DotNetStringValue.StringValue(NewColorArgb);
+    END;
+
+    [External]
+    PROCEDURE SetColorTheme@17024405(NewColorTheme@17024400 : 'Dark1,Light1,Dark2,Light2,Accent1,Accent2,Accent3,Accent4,Accent5,Accent6,Hyperlink,FollowedHyperlink,None,Background1,Text1,Background2,Text2');
+    VAR
+      DotNetThemeColorValues@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.ThemeColorValues";
+      DotNetEnumValue@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.EnumValue`1";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.CreateEnumValueGeneric(GETDOTNETTYPE(DotNetThemeColorValues), NewColorTheme, DotNetEnumValue);
+      DotNetColor.ThemeColor := DotNetEnumValue;
+    END;
+
+    PROCEDURE SetColor@17024411(NewDotNetColor@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Color");
+    BEGIN
+      DotNetColor := NewDotNetColor;
+    END;
+
+    PROCEDURE GetColor@17024400(VAR CurrentDotNetColor@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Color");
+    BEGIN
+      CurrentDotNetColor := DotNetColor;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50037.TXT
+++ b/BaseApp/COD50037.TXT
@@ -1,0 +1,117 @@
+OBJECT Codeunit 50037 DotNet_Word.StyleRunProperties
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetStyleRunProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.StyleRunProperties";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetStyleRunProperties := DotNetStyleRunProperties.StyleRunProperties;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetStyleRunProperties := DotNetStyleRunProperties.StyleRunProperties(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetStyleRunProperties.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetStyleRunProperties.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetBold@17024405(Bold@17024401 : Boolean);
+    VAR
+      DotNetBold@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Bold";
+      DotNetBoldNull@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Bold";
+    BEGIN
+      DotNetBold := DotNetBold.Bold;
+      IF Bold THEN
+        DotNetStyleRunProperties.Bold := DotNetBold
+      ELSE
+        DotNetStyleRunProperties.Bold := DotNetBoldNull;
+    END;
+
+    [External]
+    PROCEDURE SetItalic@17024409(Italic@17024401 : Boolean);
+    VAR
+      DotNetItalic@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Italic";
+      DotNetItalicNull@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Italic";
+    BEGIN
+      DotNetItalic := DotNetItalic.Italic;
+      IF Italic THEN
+        DotNetStyleRunProperties.Italic := DotNetItalic
+      ELSE
+        DotNetStyleRunProperties.Italic := DotNetItalicNull;
+    END;
+
+    [External]
+    PROCEDURE SetUnderline@17024401(Underline@17024401 : Boolean);
+    VAR
+      DotNetUnderline@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Underline";
+      DotNetUnderlineNull@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Underline";
+    BEGIN
+      DotNetUnderline := DotNetUnderline.Underline;
+      IF Underline THEN
+        DotNetStyleRunProperties.Underline := DotNetUnderline
+      ELSE
+        DotNetStyleRunProperties.Underline := DotNetUnderlineNull;
+    END;
+
+    [External]
+    PROCEDURE SetFontSize@17024406(NewFontSize@17024401 : Text);
+    VAR
+      DotNetFontSize@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.FontSize";
+      DotNetStringValue@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetFontSize := DotNetFontSize.FontSize;
+      DotNetFontSize.Val := DotNetStringValue.StringValue(NewFontSize);
+      DotNetStyleRunProperties.FontSize := DotNetFontSize;
+    END;
+
+    [External]
+    PROCEDURE SetColor@17024404(VAR WordColor@17024401 : Codeunit 50036);
+    VAR
+      DotNetColor@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Color";
+    BEGIN
+      WordColor.GetColor(DotNetColor);
+      DotNetStyleRunProperties.Color := DotNetColor;
+    END;
+
+    PROCEDURE SetStyleRunProperties@17024411(NewDotNetStyleRunProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.StyleRunProperties");
+    BEGIN
+      DotNetStyleRunProperties := NewDotNetStyleRunProperties;
+    END;
+
+    PROCEDURE GetStyleRunProperties@17024400(VAR CurrentDotNetStyleRunProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.StyleRunProperties");
+    BEGIN
+      CurrentDotNetStyleRunProperties := DotNetStyleRunProperties;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50038.TXT
+++ b/BaseApp/COD50038.TXT
@@ -1,0 +1,164 @@
+OBJECT Codeunit 50038 DotNet_Word.Style
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetStyle@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Style";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetStyle := DotNetStyle.Style;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024416(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetStyle := DotNetStyle.Style(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024414() : Text;
+    BEGIN
+      EXIT(DotNetStyle.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024412() : Text;
+    BEGIN
+      EXIT(DotNetStyle.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetStyleName@17024405(NewStyleName@17024401 : Text);
+    VAR
+      DotNetStyleName@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.StyleName";
+      DotNetStringValue@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetStyleName := DotNetStyleName.StyleName;
+      DotNetStyleName.Val := DotNetStringValue.StringValue(NewStyleName);
+      DotNetStyle.StyleName := DotNetStyleName;
+    END;
+
+    [External]
+    PROCEDURE GetStyleName@17024413() : Text;
+    BEGIN
+      EXIT(DotNetStyle.StyleName.Val.Value);
+    END;
+
+    [External]
+    PROCEDURE SetBasedOn@17024409(NewBasedOn@17024401 : Text);
+    VAR
+      DotNetBasedOn@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.BasedOn";
+      DotNetStringValue@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetBasedOn := DotNetBasedOn.BasedOn;
+      DotNetBasedOn.Val := DotNetStringValue.StringValue(NewBasedOn);
+      DotNetStyle.BasedOn := DotNetBasedOn;
+    END;
+
+    [External]
+    PROCEDURE SetNextParagraphStyle@17024401(NewNextParagraphStyle@17024401 : Text);
+    VAR
+      DotNetNextParagraphStyle@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.NextParagraphStyle";
+      DotNetStringValue@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetNextParagraphStyle := DotNetNextParagraphStyle.NextParagraphStyle;
+      DotNetNextParagraphStyle.Val := DotNetStringValue.StringValue(NewNextParagraphStyle);
+      DotNetStyle.NextParagraphStyle := DotNetNextParagraphStyle;
+    END;
+
+    [External]
+    PROCEDURE SetUIPriority@17024406(NewUIPriority@17024401 : Integer);
+    VAR
+      DotNetUIPriority@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.UIPriority";
+      DotNetInt32Value@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Int32Value";
+    BEGIN
+      DotNetUIPriority := DotNetUIPriority.UIPriority;
+      DotNetUIPriority.Val := DotNetInt32Value.FromInt32(NewUIPriority);
+      DotNetStyle.UIPriority := DotNetUIPriority;
+    END;
+
+    [External]
+    PROCEDURE SetStyleId@17024404(NewStyleId@17024401 : Text);
+    VAR
+      DotNetStringValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetStyle.StyleId := DotNetStringValue.StringValue(NewStyleId);
+    END;
+
+    [External]
+    PROCEDURE GetStyleId@17024415() : Text;
+    BEGIN
+      EXIT(DotNetStyle.StyleId.Value);
+    END;
+
+    [External]
+    PROCEDURE SetCustomStyle@17024407(CustomStyle@17024401 : Boolean);
+    VAR
+      DotNetOnOffValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.OnOffValue";
+    BEGIN
+      DotNetStyle.CustomStyle := DotNetOnOffValue.FromBoolean(CustomStyle);
+    END;
+
+    [External]
+    PROCEDURE SetStyleType@17024410(NewStyleType@17024401 : 'Paragraph,Character,Table,Numbering');
+    VAR
+      DotNetStyleValues@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.StyleValues";
+      DotNetEnumValue@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.EnumValue`1";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.CreateEnumValueGeneric(GETDOTNETTYPE(DotNetStyleValues), NewStyleType, DotNetEnumValue);
+      DotNetStyle.Type := DotNetEnumValue;
+    END;
+
+    [External]
+    PROCEDURE GetStyleType@17024408() : Integer;
+    VAR
+      DotNetStyleValues@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.StyleValues";
+      DotNetEnumValue@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.EnumValue`1";
+    BEGIN
+      DotNetEnumValue := DotNetStyle.Type;
+      DotNetStyleValues := DotNetEnumValue.Value;
+      EXIT(DotNetStyleValues);
+    END;
+
+    [External]
+    PROCEDURE AppendStyleRunProperties@17024402(VAR WordStyleRunProperties@17024401 : Codeunit 50037);
+    VAR
+      DotNetStyleRunProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.StyleRunProperties";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      WordStyleRunProperties.GetStyleRunProperties(DotNetStyleRunProperties);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetStyle, DotNetStyleRunProperties);
+    END;
+
+    PROCEDURE SetStyle@17024411(NewDotNetStyle@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Style");
+    BEGIN
+      DotNetStyle := NewDotNetStyle;
+    END;
+
+    PROCEDURE GetStyle@17024400(VAR CurrentDotNetStyle@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Style");
+    BEGIN
+      CurrentDotNetStyle := DotNetStyle;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50039.TXT
+++ b/BaseApp/COD50039.TXT
@@ -1,0 +1,90 @@
+OBJECT Codeunit 50039 DotNet_Word.Styles
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetStyles@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Styles";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetStyles := DotNetStyles.Styles;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetStyles := DotNetStyles.Styles(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetStyles.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetStyles.InnerText);
+    END;
+
+    [External]
+    PROCEDURE AppendStyle@17024405(VAR WordStyle@17024401 : Codeunit 50038);
+    VAR
+      DotNetStyle@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Style";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      WordStyle.GetStyle(DotNetStyle);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetStyles, DotNetStyle);
+    END;
+
+    [External]
+    PROCEDURE Save@17024401(VAR WordStyleDefinitionPart@17024401 : Codeunit 50041);
+    VAR
+      DotNetStyleDefinitionsPart@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.StyleDefinitionsPart";
+    BEGIN
+      WordStyleDefinitionPart.GetStyleDefinitionsPart(DotNetStyleDefinitionsPart);
+      DotNetStyles.Save(DotNetStyleDefinitionsPart);
+    END;
+
+    [External]
+    PROCEDURE GetStyleEnumerator@17024413(VAR WordStylesEnumerator@17024400 : Codeunit 50040);
+    VAR
+      DotNetStyle@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Style";
+      DotNetEnumerator@17024403 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+      OpenXmlDotNetHelper@17024401 : Codeunit 50067;
+    BEGIN
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.GetEnumeratorOfTypeGeneric(DotNetStyles.Elements, GETDOTNETTYPE(DotNetStyle), DotNetEnumerator);
+      WordStylesEnumerator.SetEnumerator(DotNetEnumerator);
+    END;
+
+    PROCEDURE SetStyles@17024411(NewDotNetStyles@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Styles");
+    BEGIN
+      DotNetStyles := NewDotNetStyles;
+    END;
+
+    PROCEDURE GetStyles@17024400(VAR CurrentDotNetStyles@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Styles");
+    BEGIN
+      CurrentDotNetStyles := DotNetStyles;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50040.TXT
+++ b/BaseApp/COD50040.TXT
@@ -1,0 +1,52 @@
+OBJECT Codeunit 50040 DotNet_Word.StylesEnumerator
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+
+    PROCEDURE SetEnumerator@17024415(NewEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      DotNetEnumerator := NewEnumerator;
+    END;
+
+    PROCEDURE GetEnumerator@17024414(VAR CurrentEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      CurrentEnumerator := DotNetEnumerator;
+    END;
+
+    [External]
+    PROCEDURE Reset@17024401();
+    BEGIN
+      DotNetEnumerator.Reset;
+    END;
+
+    [External]
+    PROCEDURE MoveNext@17024402() : Boolean;
+    BEGIN
+      EXIT(DotNetEnumerator.MoveNext);
+    END;
+
+    [External]
+    PROCEDURE GetCurrent@17024403(VAR CurrentStyle@17024400 : Codeunit 50038);
+    BEGIN
+      CurrentStyle.SetStyle(DotNetEnumerator.Current);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50041.TXT
+++ b/BaseApp/COD50041.TXT
@@ -1,0 +1,49 @@
+OBJECT Codeunit 50041 DotNet_Word.StyleDefinitionPar
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetStyleDefinitionsPart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.StyleDefinitionsPart";
+
+    [External]
+    PROCEDURE SetStyles@17024403(VAR WordStyles@17024400 : Codeunit 50039);
+    VAR
+      DotNetStyles@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Styles";
+    BEGIN
+      WordStyles.GetStyles(DotNetStyles);
+      DotNetStyleDefinitionsPart.Styles := DotNetStyles;
+    END;
+
+    [External]
+    PROCEDURE GetStyles@17024401(VAR WordStyles@17024400 : Codeunit 50039);
+    BEGIN
+      WordStyles.SetStyles(DotNetStyleDefinitionsPart.Styles);
+    END;
+
+    PROCEDURE SetStyleDefinitionsPart@17024411(NewDotNetStyleDefinitionsPart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.StyleDefinitionsPart");
+    BEGIN
+      DotNetStyleDefinitionsPart := NewDotNetStyleDefinitionsPart;
+    END;
+
+    PROCEDURE GetStyleDefinitionsPart@17024400(VAR CurrentDotNetStyleDefinitionsPart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.StyleDefinitionsPart");
+    BEGIN
+      CurrentDotNetStyleDefinitionsPart := DotNetStyleDefinitionsPart;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50042.TXT
+++ b/BaseApp/COD50042.TXT
@@ -1,0 +1,40 @@
+OBJECT Codeunit 50042 DotNet_Word.ImagePart
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetImagePart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.ImagePart";
+
+    [External]
+    PROCEDURE FeedData@17024401(ImageStream@17024400 : InStream);
+    BEGIN
+      DotNetImagePart.FeedData(ImageStream);
+    END;
+
+    PROCEDURE SetImagePart@17024411(NewDotNetImagePart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.ImagePart");
+    BEGIN
+      DotNetImagePart := NewDotNetImagePart;
+    END;
+
+    PROCEDURE GetImagePart@17024400(VAR CurrentDotNetImagePart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.ImagePart");
+    BEGIN
+      CurrentDotNetImagePart := DotNetImagePart;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50043.TXT
+++ b/BaseApp/COD50043.TXT
@@ -1,0 +1,69 @@
+OBJECT Codeunit 50043 DotNet_Word.Drawing
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetDrawing@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Drawing";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetDrawing := DotNetDrawing.Drawing;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetDrawing := DotNetDrawing.Drawing(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetDrawing.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetDrawing.InnerText);
+    END;
+
+    [External]
+    PROCEDURE AppendAnchor@17024405(VAR WordAnchor@17024401 : Codeunit 50044);
+    VAR
+      DotNetAnchor@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.Anchor";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      WordAnchor.GetAnchor(DotNetAnchor);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetDrawing, DotNetAnchor);
+    END;
+
+    PROCEDURE SetDrawing@17024411(NewDotNetDrawing@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Drawing");
+    BEGIN
+      DotNetDrawing := NewDotNetDrawing;
+    END;
+
+    PROCEDURE GetDrawing@17024400(VAR CurrentDotNetDrawing@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Drawing");
+    BEGIN
+      CurrentDotNetDrawing := DotNetDrawing;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50044.TXT
+++ b/BaseApp/COD50044.TXT
@@ -1,0 +1,261 @@
+OBJECT Codeunit 50044 DotNet_Word.Anchor
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetAnchor@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.Anchor";
+      OpenXmlDotNetHelper@17024401 : Codeunit 50067;
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetAnchor := DotNetAnchor.Anchor;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024425(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetAnchor := DotNetAnchor.Anchor(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024424() : Text;
+    BEGIN
+      EXIT(DotNetAnchor.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024423() : Text;
+    BEGIN
+      EXIT(DotNetAnchor.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetAllowOverlap@17024405(NewAllowOverlap@17024401 : Boolean);
+    VAR
+      DotNetBooleanValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.BooleanValue";
+    BEGIN
+      DotNetAnchor.AllowOverlap := DotNetBooleanValue.BooleanValue(NewAllowOverlap);
+    END;
+
+    [External]
+    PROCEDURE SetLayoutInCell@17024402(NewLayoutInCell@17024401 : Boolean);
+    VAR
+      DotNetBooleanValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.BooleanValue";
+    BEGIN
+      DotNetAnchor.LayoutInCell := DotNetBooleanValue.BooleanValue(NewLayoutInCell);
+    END;
+
+    [External]
+    PROCEDURE SetLocked@17024406(NewLocked@17024401 : Boolean);
+    VAR
+      DotNetBooleanValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.BooleanValue";
+    BEGIN
+      DotNetAnchor.Locked := DotNetBooleanValue.BooleanValue(NewLocked);
+    END;
+
+    [External]
+    PROCEDURE SetBehindDoc@17024408(NewBehindDoc@17024401 : Boolean);
+    VAR
+      DotNetBooleanValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.BooleanValue";
+    BEGIN
+      DotNetAnchor.BehindDoc := DotNetBooleanValue.BooleanValue(NewBehindDoc);
+    END;
+
+    [External]
+    PROCEDURE SetSimplePos@17024409(NewSimplePos@17024401 : Boolean);
+    VAR
+      DotNetBooleanValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.BooleanValue";
+    BEGIN
+      DotNetAnchor.SimplePos := DotNetBooleanValue.BooleanValue(NewSimplePos);
+    END;
+
+    [External]
+    PROCEDURE SetRelativeHeight@17024412(NewRelativeHeight@17024401 : Integer);
+    VAR
+      DotNetUInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.UInt32Value";
+    BEGIN
+      DotNetAnchor.RelativeHeight := DotNetUInt32Value.FromUInt32(NewRelativeHeight);
+    END;
+
+    [External]
+    PROCEDURE SetDistanceFromRight@17024414(NewDistance@17024401 : Integer);
+    VAR
+      DotNetUInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.UInt32Value";
+    BEGIN
+      DotNetAnchor.DistanceFromRight := DotNetUInt32Value.FromUInt32(NewDistance);
+    END;
+
+    [External]
+    PROCEDURE SetDistanceFromLeft@17024415(NewDistance@17024401 : Integer);
+    VAR
+      DotNetUInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.UInt32Value";
+    BEGIN
+      DotNetAnchor.DistanceFromLeft := DotNetUInt32Value.FromUInt32(NewDistance);
+    END;
+
+    [External]
+    PROCEDURE SetDistanceFromTop@17024416(NewDistance@17024401 : Integer);
+    VAR
+      DotNetUInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.UInt32Value";
+    BEGIN
+      DotNetAnchor.DistanceFromTop := DotNetUInt32Value.FromUInt32(NewDistance);
+    END;
+
+    [External]
+    PROCEDURE SetDistanceFromBottom@17024417(NewDistance@17024401 : Integer);
+    VAR
+      DotNetUInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.UInt32Value";
+    BEGIN
+      DotNetAnchor.DistanceFromBottom := DotNetUInt32Value.FromUInt32(NewDistance);
+    END;
+
+    [External]
+    PROCEDURE AppendSimplePosition@17024401(X@17024401 : Integer;Y@17024402 : Integer);
+    VAR
+      DotNetInt64Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Int64Value";
+      DotNetSimplePosition@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.SimplePosition";
+    BEGIN
+      DotNetSimplePosition := DotNetSimplePosition.SimplePosition;
+      DotNetSimplePosition.X := DotNetInt64Value.FromInt64(X);
+      DotNetSimplePosition.Y := DotNetInt64Value.FromInt64(Y);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetAnchor, DotNetSimplePosition);
+    END;
+
+    [External]
+    PROCEDURE AppendExtent@17024410(Cx@17024401 : Integer;Cy@17024402 : Integer);
+    VAR
+      DotNetInt64Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Int64Value";
+      DotNetExtent@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.Extent";
+    BEGIN
+      DotNetExtent := DotNetExtent.Extent;
+      DotNetExtent.Cx := DotNetInt64Value.FromInt64(Cx);
+      DotNetExtent.Cy := DotNetInt64Value.FromInt64(Cy);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetAnchor, DotNetExtent);
+    END;
+
+    [External]
+    PROCEDURE AppendEffectExtent@17024418(LeftEdge@17024401 : Integer;TopEdge@17024402 : Integer;RightEdge@17024404 : Integer;BottomEdge@17024405 : Integer);
+    VAR
+      DotNetInt64Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Int64Value";
+      DotNetEffectExtent@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.EffectExtent";
+    BEGIN
+      DotNetEffectExtent := DotNetEffectExtent.EffectExtent;
+      DotNetEffectExtent.LeftEdge := DotNetInt64Value.FromInt64(LeftEdge);
+      DotNetEffectExtent.TopEdge := DotNetInt64Value.FromInt64(TopEdge);
+      DotNetEffectExtent.RightEdge := DotNetInt64Value.FromInt64(RightEdge);
+      DotNetEffectExtent.BottomEdge := DotNetInt64Value.FromInt64(BottomEdge);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetAnchor, DotNetEffectExtent);
+    END;
+
+    [External]
+    PROCEDURE AppendVerticalPosition@17024404(VAR WordVerticalPosition@17024401 : Codeunit 50045);
+    VAR
+      DotNetVerticalPosition@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.VerticalPosition";
+    BEGIN
+      WordVerticalPosition.GetVerticalPosition(DotNetVerticalPosition);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetAnchor, DotNetVerticalPosition);
+    END;
+
+    [External]
+    PROCEDURE AppendHorizontalPosition@17024413(VAR WordHorizontalPosition@17024401 : Codeunit 50046);
+    VAR
+      DotNetHorizontalPosition@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalPosition";
+    BEGIN
+      WordHorizontalPosition.GetHorizontalPosition(DotNetHorizontalPosition);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetAnchor, DotNetHorizontalPosition);
+    END;
+
+    [External]
+    PROCEDURE AppendWrapSquare@17024407(VAR WordWrapSquare@17024401 : Codeunit 50047);
+    VAR
+      DotNetWrapSquare@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.WrapSquare";
+    BEGIN
+      WordWrapSquare.GetWrapSquare(DotNetWrapSquare);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetAnchor, DotNetWrapSquare);
+    END;
+
+    [External]
+    PROCEDURE AppendWrapTopBottom@17024419(VAR WordWrapTopBottom@17024401 : Codeunit 50048);
+    VAR
+      DotNetWrapTopBottom@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.WrapTopBottom";
+    BEGIN
+      WordWrapTopBottom.GetWrapTopBottom(DotNetWrapTopBottom);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetAnchor, DotNetWrapTopBottom);
+    END;
+
+    [External]
+    PROCEDURE AppendDocProperties@17024420(VAR WordDocProperties@17024401 : Codeunit 50049);
+    VAR
+      DotNetDocProperties@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties";
+    BEGIN
+      WordDocProperties.GetDocProperties(DotNetDocProperties);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetAnchor, DotNetDocProperties);
+    END;
+
+    [External]
+    PROCEDURE AppendGraphicFrameLocks@17024421(VAR WordGraphicFrameLocks@17024401 : Codeunit 50050);
+    VAR
+      DotNetGraphicFrameLocks@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.GraphicFrameLocks";
+      DotNetNonVisualGraphicFrameDrawingProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.NonVisualGraphicFrameDrawingProperties";
+    BEGIN
+      WordGraphicFrameLocks.GetGraphicFrameLocks(DotNetGraphicFrameLocks);
+      DotNetNonVisualGraphicFrameDrawingProperties := DotNetNonVisualGraphicFrameDrawingProperties.NonVisualGraphicFrameDrawingProperties;
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetNonVisualGraphicFrameDrawingProperties, DotNetGraphicFrameLocks);
+      OpenXmlDotNetHelper.AppendGeneric(DotNetAnchor, DotNetNonVisualGraphicFrameDrawingProperties);
+    END;
+
+    [External]
+    PROCEDURE AppendPicture@17024422(VAR WordPicture@17024401 : Codeunit 50051);
+    VAR
+      DotNetPicture@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.Picture";
+      DotNetGraphicData@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.GraphicData";
+      DotNetGraphic@17024404 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Graphic";
+      DotNetStringValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      WordPicture.GetPicture(DotNetPicture);
+      DotNetGraphic := DotNetGraphic.Graphic;
+      DotNetGraphicData := DotNetGraphicData.GraphicData;
+      DotNetGraphicData.Uri := DotNetStringValue.FromString('http://schemas.openxmlformats.org/drawingml/2006/picture');
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetGraphicData, DotNetPicture);
+      OpenXmlDotNetHelper.AppendGeneric(DotNetGraphic, DotNetGraphicData);
+      OpenXmlDotNetHelper.AppendGeneric(DotNetAnchor, DotNetGraphic);
+    END;
+
+    PROCEDURE SetAnchor@17024411(NewDotNetAnchor@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.Anchor");
+    BEGIN
+      DotNetAnchor := NewDotNetAnchor;
+    END;
+
+    PROCEDURE GetAnchor@17024400(VAR CurrentDotNetAnchor@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.Anchor");
+    BEGIN
+      CurrentDotNetAnchor := DotNetAnchor;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50045.TXT
+++ b/BaseApp/COD50045.TXT
@@ -1,0 +1,93 @@
+OBJECT Codeunit 50045 DotNet_Word.VerticalPosition
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetVerticalPosition@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.VerticalPosition";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetVerticalPosition := DotNetVerticalPosition.VerticalPosition;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024404(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetVerticalPosition := DotNetVerticalPosition.VerticalPosition(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetVerticalPosition.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024401() : Text;
+    BEGIN
+      EXIT(DotNetVerticalPosition.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetPositionOffset@17024405(NewPositionOffset@17024401 : Text);
+    VAR
+      DotNetPositionOffset@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.PositionOffset";
+    BEGIN
+      DotNetVerticalPosition.PositionOffset := DotNetPositionOffset.PositionOffset(NewPositionOffset);
+    END;
+
+    [External]
+    PROCEDURE SetRelativeFrom@17024408(NewRelativeFrom@17024401 : 'Margin,Page,Paragraph,Line,TopMargin,BottomMargin,InsideMargin,OutsideMargin');
+    VAR
+      DotNetVerticalRelativePositionValues@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.VerticalRelativePositionValues";
+      DotNetEnumValue@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.EnumValue`1";
+      OpenXmlDotNetHelper@17024400 : Codeunit 50067;
+    BEGIN
+      OpenXmlDotNetHelper.CreateEnumValueGeneric(GETDOTNETTYPE(DotNetVerticalRelativePositionValues), NewRelativeFrom, DotNetEnumValue);
+      DotNetVerticalPosition.RelativeFrom := DotNetEnumValue;
+    END;
+
+    [External]
+    PROCEDURE SetVerticalAlignment@17024410(NewVerticalAlignment@17024401 : Text);
+    VAR
+      DotNetVerticalAlignment@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.VerticalAlignment";
+    BEGIN
+      DotNetVerticalPosition.VerticalAlignment := DotNetVerticalAlignment.VerticalAlignment(NewVerticalAlignment);
+    END;
+
+    [External]
+    PROCEDURE SetPercentagePositionVerticalOffset@17024413(NewPercentagePositionVerticalOffset@17024401 : Text);
+    VAR
+      DotNetPercentagePositionVerticalOffset@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentagePositionVerticalOffset";
+    BEGIN
+      DotNetVerticalPosition.PercentagePositionVerticalOffset := DotNetPercentagePositionVerticalOffset.PercentagePositionVerticalOffset(NewPercentagePositionVerticalOffset);
+    END;
+
+    PROCEDURE SetVerticalPosition@17024411(NewDotNetVerticalPosition@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.VerticalPosition");
+    BEGIN
+      DotNetVerticalPosition := NewDotNetVerticalPosition;
+    END;
+
+    PROCEDURE GetVerticalPosition@17024400(VAR CurrentDotNetVerticalPosition@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.VerticalPosition");
+    BEGIN
+      CurrentDotNetVerticalPosition := DotNetVerticalPosition;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50046.TXT
+++ b/BaseApp/COD50046.TXT
@@ -1,0 +1,93 @@
+OBJECT Codeunit 50046 DotNet_Word.HorizontalPosition
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetHorizontalPosition@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalPosition";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetHorizontalPosition := DotNetHorizontalPosition.HorizontalPosition;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024404(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetHorizontalPosition := DotNetHorizontalPosition.HorizontalPosition(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetHorizontalPosition.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024401() : Text;
+    BEGIN
+      EXIT(DotNetHorizontalPosition.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetPositionOffset@17024405(NewPositionOffset@17024401 : Text);
+    VAR
+      DotNetPositionOffset@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.PositionOffset";
+    BEGIN
+      DotNetHorizontalPosition.PositionOffset := DotNetPositionOffset.PositionOffset(NewPositionOffset);
+    END;
+
+    [External]
+    PROCEDURE SetRelativeFrom@17024408(NewRelativeFrom@17024401 : 'Margin,Page,Column,Character,LeftMargin,RightMargin,InsideMargin,OutsideMargin');
+    VAR
+      DotNetHorizontalRelativePositionValues@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalRelativePositionValues";
+      DotNetEnumValue@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.EnumValue`1";
+      OpenXmlDotNetHelper@17024400 : Codeunit 50067;
+    BEGIN
+      OpenXmlDotNetHelper.CreateEnumValueGeneric(GETDOTNETTYPE(DotNetHorizontalRelativePositionValues), NewRelativeFrom, DotNetEnumValue);
+      DotNetHorizontalPosition.RelativeFrom := DotNetEnumValue;
+    END;
+
+    [External]
+    PROCEDURE SetHorizontalAlignment@17024410(NewHorizontalAlignment@17024401 : Text);
+    VAR
+      DotNetHorizontalAlignment@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalAlignment";
+    BEGIN
+      DotNetHorizontalPosition.HorizontalAlignment := DotNetHorizontalAlignment.HorizontalAlignment(NewHorizontalAlignment);
+    END;
+
+    [External]
+    PROCEDURE SetPercentagePositionHeightOffset@17024413(NewPercentagePositionHeightOffset@17024401 : Text);
+    VAR
+      DotNetPercentagePositionHeigthOffset@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Office2010.Word.Drawing.PercentagePositionHeightOffset";
+    BEGIN
+      DotNetHorizontalPosition.PercentagePositionHeightOffset := DotNetPercentagePositionHeigthOffset.PercentagePositionHeightOffset(NewPercentagePositionHeightOffset);
+    END;
+
+    PROCEDURE SetHorizontalPosition@17024411(NewDotNetHorizontalPosition@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalPosition");
+    BEGIN
+      DotNetHorizontalPosition := NewDotNetHorizontalPosition;
+    END;
+
+    PROCEDURE GetHorizontalPosition@17024400(VAR CurrentDotNetHorizontalPosition@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.HorizontalPosition");
+    BEGIN
+      CurrentDotNetHorizontalPosition := DotNetHorizontalPosition;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50047.TXT
+++ b/BaseApp/COD50047.TXT
@@ -1,0 +1,117 @@
+OBJECT Codeunit 50047 DotNet_Word.WrapSquare
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetWrapSquare@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.WrapSquare";
+      OpenXmlDotNetHelper@17024401 : Codeunit 50067;
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetWrapSquare := DotNetWrapSquare.WrapSquare;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024401(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetWrapSquare := DotNetWrapSquare.WrapSquare(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetWrapSquare.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetWrapSquare.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetDistanceFromRight@17024414(NewDistance@17024401 : Integer);
+    VAR
+      DotNetUInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.UInt32Value";
+    BEGIN
+      DotNetWrapSquare.DistanceFromRight := DotNetUInt32Value.FromUInt32(NewDistance);
+    END;
+
+    [External]
+    PROCEDURE SetDistanceFromLeft@17024415(NewDistance@17024401 : Integer);
+    VAR
+      DotNetUInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.UInt32Value";
+    BEGIN
+      DotNetWrapSquare.DistanceFromLeft := DotNetUInt32Value.FromUInt32(NewDistance);
+    END;
+
+    [External]
+    PROCEDURE SetDistanceFromTop@17024416(NewDistance@17024401 : Integer);
+    VAR
+      DotNetUInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.UInt32Value";
+    BEGIN
+      DotNetWrapSquare.DistanceFromTop := DotNetUInt32Value.FromUInt32(NewDistance);
+    END;
+
+    [External]
+    PROCEDURE SetDistanceFromBottom@17024417(NewDistance@17024401 : Integer);
+    VAR
+      DotNetUInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.UInt32Value";
+    BEGIN
+      DotNetWrapSquare.DistanceFromBottom := DotNetUInt32Value.FromUInt32(NewDistance);
+    END;
+
+    [External]
+    PROCEDURE SetWrapText@17024408(NewWrapText@17024401 : 'BothSides,Left,Right,Largest');
+    VAR
+      DotNetWrapTextValues@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.WrapTextValues";
+      DotNetEnumValue@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.EnumValue`1";
+    BEGIN
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.CreateEnumValueGeneric(GETDOTNETTYPE(DotNetWrapTextValues), NewWrapText, DotNetEnumValue);
+      DotNetWrapSquare.WrapText := DotNetEnumValue;
+    END;
+
+    [External]
+    PROCEDURE AppendEffectExtent@17024418(LeftEdge@17024401 : Integer;TopEdge@17024402 : Integer;RightEdge@17024404 : Integer;BottomEdge@17024405 : Integer);
+    VAR
+      DotNetInt64Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Int64Value";
+      DotNetEffectExtent@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.EffectExtent";
+    BEGIN
+      DotNetEffectExtent := DotNetEffectExtent.EffectExtent;
+      DotNetEffectExtent.LeftEdge := DotNetInt64Value.FromInt64(LeftEdge);
+      DotNetEffectExtent.TopEdge := DotNetInt64Value.FromInt64(TopEdge);
+      DotNetEffectExtent.RightEdge := DotNetInt64Value.FromInt64(RightEdge);
+      DotNetEffectExtent.BottomEdge := DotNetInt64Value.FromInt64(BottomEdge);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetWrapSquare, DotNetEffectExtent);
+    END;
+
+    PROCEDURE SetWrapSquare@17024411(NewDotNetWrapSquare@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.WrapSquare");
+    BEGIN
+      DotNetWrapSquare := NewDotNetWrapSquare;
+    END;
+
+    PROCEDURE GetWrapSquare@17024400(VAR CurrentDotNetWrapSquare@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.WrapSquare");
+    BEGIN
+      CurrentDotNetWrapSquare := DotNetWrapSquare;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50048.TXT
+++ b/BaseApp/COD50048.TXT
@@ -1,0 +1,90 @@
+OBJECT Codeunit 50048 DotNet_Word.WrapTopBottom
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetWrapTopBottom@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.WrapTopBottom";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetWrapTopBottom := DotNetWrapTopBottom.WrapTopBottom;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetWrapTopBottom := DotNetWrapTopBottom.WrapTopBottom;
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetWrapTopBottom.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetWrapTopBottom.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetDistanceFromTop@17024416(NewDistance@17024401 : Integer);
+    VAR
+      DotNetUInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.UInt32Value";
+    BEGIN
+      DotNetWrapTopBottom.DistanceFromTop := DotNetUInt32Value.FromUInt32(NewDistance);
+    END;
+
+    [External]
+    PROCEDURE SetDistanceFromBottom@17024417(NewDistance@17024401 : Integer);
+    VAR
+      DotNetUInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.UInt32Value";
+    BEGIN
+      DotNetWrapTopBottom.DistanceFromBottom := DotNetUInt32Value.FromUInt32(NewDistance);
+    END;
+
+    [External]
+    PROCEDURE AppendEffectExtent@17024418(LeftEdge@17024401 : Integer;TopEdge@17024402 : Integer;RightEdge@17024404 : Integer;BottomEdge@17024405 : Integer);
+    VAR
+      DotNetInt64Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Int64Value";
+      DotNetEffectExtent@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.EffectExtent";
+      OpenXmlDotNetHelper@17024406 : Codeunit 50067;
+    BEGIN
+      DotNetEffectExtent := DotNetEffectExtent.EffectExtent;
+      DotNetEffectExtent.LeftEdge := DotNetInt64Value.FromInt64(LeftEdge);
+      DotNetEffectExtent.TopEdge := DotNetInt64Value.FromInt64(TopEdge);
+      DotNetEffectExtent.RightEdge := DotNetInt64Value.FromInt64(RightEdge);
+      DotNetEffectExtent.BottomEdge := DotNetInt64Value.FromInt64(BottomEdge);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetWrapTopBottom, DotNetEffectExtent);
+    END;
+
+    PROCEDURE SetWrapTopBottom@17024411(NewDotNetWrapTopBottom@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.WrapTopBottom");
+    BEGIN
+      DotNetWrapTopBottom := NewDotNetWrapTopBottom;
+    END;
+
+    PROCEDURE GetWrapTopBottom@17024400(VAR CurrentDotNetWrapTopBottom@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.WrapTopBottom");
+    BEGIN
+      CurrentDotNetWrapTopBottom := DotNetWrapTopBottom;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50049.TXT
+++ b/BaseApp/COD50049.TXT
@@ -1,0 +1,90 @@
+OBJECT Codeunit 50049 DotNet_Word.DocProperties
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetDocProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetDocProperties := DotNetDocProperties.DocProperties;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetDocProperties := DotNetDocProperties.DocProperties(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetDocProperties.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetDocProperties.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetId@17024416(NewId@17024401 : Integer);
+    VAR
+      DotNetUInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.UInt32Value";
+    BEGIN
+      DotNetDocProperties.Id := DotNetUInt32Value.FromUInt32(NewId);
+    END;
+
+    [External]
+    PROCEDURE SetName@17024417(NewName@17024401 : Text);
+    VAR
+      DotNetStringValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetDocProperties.Name := DotNetStringValue.FromString(NewName);
+    END;
+
+    [External]
+    PROCEDURE SetDescription@17024406(NewDescription@17024401 : Text);
+    VAR
+      DotNetStringValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetDocProperties.Description := DotNetStringValue.FromString(NewDescription);
+    END;
+
+    [External]
+    PROCEDURE SetTitle@17024407(NewTitle@17024401 : Text);
+    VAR
+      DotNetStringValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetDocProperties.Title := DotNetStringValue.FromString(NewTitle);
+    END;
+
+    PROCEDURE SetDocProperties@17024411(NewDotNetDocProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties");
+    BEGIN
+      DotNetDocProperties := NewDotNetDocProperties;
+    END;
+
+    PROCEDURE GetDocProperties@17024400(VAR CurrentDotNetDocProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Wordprocessing.DocProperties");
+    BEGIN
+      CurrentDotNetDocProperties := DotNetDocProperties;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50050.TXT
+++ b/BaseApp/COD50050.TXT
@@ -1,0 +1,106 @@
+OBJECT Codeunit 50050 DotNet_Word.GraphicFrameLocks
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetGraphicFrameLocks@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.GraphicFrameLocks";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetGraphicFrameLocks := DotNetGraphicFrameLocks.GraphicFrameLocks;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024401(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetGraphicFrameLocks := DotNetGraphicFrameLocks.GraphicFrameLocks(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetGraphicFrameLocks.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetGraphicFrameLocks.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetNoGrouping@17024416(NewNoGrouping@17024401 : Boolean);
+    VAR
+      DotNetBooleanValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.BooleanValue";
+    BEGIN
+      DotNetGraphicFrameLocks.NoGrouping := DotNetBooleanValue.FromBoolean(NewNoGrouping);
+    END;
+
+    [External]
+    PROCEDURE SetNoDrilldown@17024405(NewNoDrillDown@17024401 : Boolean);
+    VAR
+      DotNetBooleanValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.BooleanValue";
+    BEGIN
+      DotNetGraphicFrameLocks.NoDrilldown := DotNetBooleanValue.FromBoolean(NewNoDrillDown);
+    END;
+
+    [External]
+    PROCEDURE SetNoSelection@17024406(NewNoSelection@17024401 : Boolean);
+    VAR
+      DotNetBooleanValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.BooleanValue";
+    BEGIN
+      DotNetGraphicFrameLocks.NoSelection := DotNetBooleanValue.FromBoolean(NewNoSelection);
+    END;
+
+    [External]
+    PROCEDURE SetNoChangeAspect@17024407(NewNoChangeAspect@17024401 : Boolean);
+    VAR
+      DotNetBooleanValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.BooleanValue";
+    BEGIN
+      DotNetGraphicFrameLocks.NoChangeAspect := DotNetBooleanValue.FromBoolean(NewNoChangeAspect);
+    END;
+
+    [External]
+    PROCEDURE SetNoMove@17024408(NewNoMove@17024401 : Boolean);
+    VAR
+      DotNetBooleanValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.BooleanValue";
+    BEGIN
+      DotNetGraphicFrameLocks.NoMove := DotNetBooleanValue.FromBoolean(NewNoMove);
+    END;
+
+    [External]
+    PROCEDURE SetNoResize@17024409(NewNoResize@17024401 : Boolean);
+    VAR
+      DotNetBooleanValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.BooleanValue";
+    BEGIN
+      DotNetGraphicFrameLocks.NoResize := DotNetBooleanValue.FromBoolean(NewNoResize);
+    END;
+
+    PROCEDURE SetGraphicFrameLocks@17024411(NewDotNetGraphicFrameLocks@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.GraphicFrameLocks");
+    BEGIN
+      DotNetGraphicFrameLocks := NewDotNetGraphicFrameLocks;
+    END;
+
+    PROCEDURE GetGraphicFrameLocks@17024400(VAR CurrentDotNetGraphicFrameLocks@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.GraphicFrameLocks");
+    BEGIN
+      CurrentDotNetGraphicFrameLocks := DotNetGraphicFrameLocks;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50051.TXT
+++ b/BaseApp/COD50051.TXT
@@ -1,0 +1,85 @@
+OBJECT Codeunit 50051 DotNet_Word.Picture
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetPicture@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.Picture";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetPicture := DotNetPicture.Picture;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetPicture := DotNetPicture.Picture(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetPicture.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetPicture.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetNonVisualPictureProperties@17024416(VAR WordNonVisualPictureProperties@17024401 : Codeunit 50052);
+    VAR
+      DotNetNonVisualPictureProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.NonVisualPictureProperties";
+    BEGIN
+      WordNonVisualPictureProperties.GetNonVisualPictureProperties(DotNetNonVisualPictureProperties);
+      DotNetPicture.NonVisualPictureProperties := DotNetNonVisualPictureProperties;
+    END;
+
+    [External]
+    PROCEDURE SetShapeProperties@17024405(VAR WordShapeProperties@17024401 : Codeunit 50053);
+    VAR
+      DotNetShapeProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.ShapeProperties";
+    BEGIN
+      WordShapeProperties.GetShapeProperties(DotNetShapeProperties);
+      DotNetPicture.ShapeProperties := DotNetShapeProperties;
+    END;
+
+    [External]
+    PROCEDURE SetBlipFill@17024407(VAR WordBlipFill@17024401 : Codeunit 50054);
+    VAR
+      DotNetBlipFill@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.BlipFill";
+    BEGIN
+      WordBlipFill.GetBlipFill(DotNetBlipFill);
+      DotNetPicture.BlipFill := DotNetBlipFill;
+    END;
+
+    PROCEDURE SetPicture@17024411(NewDotNetPicture@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.Picture");
+    BEGIN
+      DotNetPicture := NewDotNetPicture;
+    END;
+
+    PROCEDURE GetPicture@17024400(VAR CurrentDotNetPicture@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.Picture");
+    BEGIN
+      CurrentDotNetPicture := DotNetPicture;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50052.TXT
+++ b/BaseApp/COD50052.TXT
@@ -1,0 +1,76 @@
+OBJECT Codeunit 50052 DotNet_Word.NonVisualPicturePr
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetNonVisualPictureProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.NonVisualPictureProperties";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetNonVisualPictureProperties := DotNetNonVisualPictureProperties.NonVisualPictureProperties;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetNonVisualPictureProperties := DotNetNonVisualPictureProperties.NonVisualPictureProperties(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024401() : Text;
+    BEGIN
+      EXIT(DotNetNonVisualPictureProperties.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetNonVisualPictureProperties.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetNonVisualDrawingProperties@17024416(VAR WordNonVisualDrawingProperties@17024401 : Codeunit 50055);
+    VAR
+      DotNetNonVisualDrawingProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.NonVisualDrawingProperties";
+    BEGIN
+      WordNonVisualDrawingProperties.GetNonVisualDrawingProperties(DotNetNonVisualDrawingProperties);
+      DotNetNonVisualPictureProperties.NonVisualDrawingProperties := DotNetNonVisualDrawingProperties;
+    END;
+
+    [External]
+    PROCEDURE SetNonVisualPictureDrawingProperties@17024402(VAR WordNonVisualPictureDrawingProperties@17024401 : Codeunit 50056);
+    VAR
+      DotNetNonVisualPictureDrawingProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.NonVisualPictureDrawingProperties";
+    BEGIN
+      WordNonVisualPictureDrawingProperties.GetNonVisualPictureDrawingProperties(DotNetNonVisualPictureDrawingProperties);
+      DotNetNonVisualPictureProperties.NonVisualPictureDrawingProperties := DotNetNonVisualPictureDrawingProperties;
+    END;
+
+    PROCEDURE SetNonVisualPictureProperties@17024411(NewDotNetNonVisualPictureProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.NonVisualPictureProperties");
+    BEGIN
+      DotNetNonVisualPictureProperties := NewDotNetNonVisualPictureProperties;
+    END;
+
+    PROCEDURE GetNonVisualPictureProperties@17024400(VAR CurrentDotNetNonVisualPictureProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.NonVisualPictureProperties");
+    BEGIN
+      CurrentDotNetNonVisualPictureProperties := DotNetNonVisualPictureProperties;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50053.TXT
+++ b/BaseApp/COD50053.TXT
@@ -1,0 +1,78 @@
+OBJECT Codeunit 50053 DotNet_Word.ShapeProperties
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetShapeProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.ShapeProperties";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetShapeProperties := DotNetShapeProperties.ShapeProperties;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetShapeProperties := DotNetShapeProperties.ShapeProperties(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetShapeProperties.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetShapeProperties.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetTransform2D@17024416(VAR WordTransform2D@17024401 : Codeunit 50060);
+    VAR
+      DotNetTransform2D@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Transform2D";
+    BEGIN
+      WordTransform2D.GetTransform2D(DotNetTransform2D);
+      DotNetShapeProperties.Transform2D := DotNetTransform2D;
+    END;
+
+    [External]
+    PROCEDURE AppendPresetGeometry@17024404(VAR WordPresetGeometry@17024401 : Codeunit 50061);
+    VAR
+      DotNetPresetGeometry@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.PresetGeometry";
+      OpenXmlDotNetHelper@17024400 : Codeunit 50067;
+    BEGIN
+      WordPresetGeometry.GetPresetGeometry(DotNetPresetGeometry);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetShapeProperties, DotNetPresetGeometry);
+    END;
+
+    PROCEDURE SetShapeProperties@17024411(NewDotNetShapeProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.ShapeProperties");
+    BEGIN
+      DotNetShapeProperties := NewDotNetShapeProperties;
+    END;
+
+    PROCEDURE GetShapeProperties@17024400(VAR CurrentDotNetShapeProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.ShapeProperties");
+    BEGIN
+      CurrentDotNetShapeProperties := DotNetShapeProperties;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50054.TXT
+++ b/BaseApp/COD50054.TXT
@@ -1,0 +1,78 @@
+OBJECT Codeunit 50054 DotNet_Word.BlipFill
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetBlipFill@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.BlipFill";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetBlipFill := DotNetBlipFill.BlipFill;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetBlipFill := DotNetBlipFill.BlipFill(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetBlipFill.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetBlipFill.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetBlip@17024416(VAR WordBlip@17024401 : Codeunit 50057);
+    VAR
+      DotNetBlip@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Blip";
+    BEGIN
+      WordBlip.GetBlip(DotNetBlip);
+      DotNetBlipFill.Blip := DotNetBlip;
+    END;
+
+    [External]
+    PROCEDURE AppendStretch@17024404(VAR WordStretch@17024401 : Codeunit 50058);
+    VAR
+      DotNetStretch@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Stretch";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      WordStretch.GetStretch(DotNetStretch);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetBlipFill, DotNetStretch);
+    END;
+
+    PROCEDURE SetBlipFill@17024411(NewDotNetBlipFill@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.BlipFill");
+    BEGIN
+      DotNetBlipFill := NewDotNetBlipFill;
+    END;
+
+    PROCEDURE GetBlipFill@17024400(VAR CurrentDotNetBlipFill@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.BlipFill");
+    BEGIN
+      CurrentDotNetBlipFill := DotNetBlipFill;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50055.TXT
+++ b/BaseApp/COD50055.TXT
@@ -1,0 +1,90 @@
+OBJECT Codeunit 50055 DotNet_Word.NonVisualDrawingPr
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetNonVisualDrawingProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.NonVisualDrawingProperties";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetNonVisualDrawingProperties := DotNetNonVisualDrawingProperties.NonVisualDrawingProperties;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetNonVisualDrawingProperties := DotNetNonVisualDrawingProperties.NonVisualDrawingProperties(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024401() : Text;
+    BEGIN
+      EXIT(DotNetNonVisualDrawingProperties.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetNonVisualDrawingProperties.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetName@17024416(NewName@17024401 : Text);
+    VAR
+      DotNetStringValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetNonVisualDrawingProperties.Name := DotNetStringValue.FromString(NewName);
+    END;
+
+    [External]
+    PROCEDURE SetDescription@17024402(NewDescription@17024401 : Text);
+    VAR
+      DotNetStringValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetNonVisualDrawingProperties.Description := DotNetStringValue.FromString(NewDescription);
+    END;
+
+    [External]
+    PROCEDURE SetTitle@17024404(NewTitle@17024401 : Text);
+    VAR
+      DotNetStringValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetNonVisualDrawingProperties.Title := DotNetStringValue.FromString(NewTitle);
+    END;
+
+    [External]
+    PROCEDURE SetId@17024406(NewId@17024401 : Integer);
+    VAR
+      DotNetUInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.UInt32Value";
+    BEGIN
+      DotNetNonVisualDrawingProperties.Id := DotNetUInt32Value.FromUInt32(NewId);
+    END;
+
+    PROCEDURE SetNonVisualDrawingProperties@17024411(NewDotNetNonVisualDrawingProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.NonVisualDrawingProperties");
+    BEGIN
+      DotNetNonVisualDrawingProperties := NewDotNetNonVisualDrawingProperties;
+    END;
+
+    PROCEDURE GetNonVisualDrawingProperties@17024400(VAR CurrentDotNetNonVisualDrawingProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.NonVisualDrawingProperties");
+    BEGIN
+      CurrentDotNetNonVisualDrawingProperties := DotNetNonVisualDrawingProperties;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50056.TXT
+++ b/BaseApp/COD50056.TXT
@@ -1,0 +1,66 @@
+OBJECT Codeunit 50056 DotNet_Word.NonVisualPictureDr
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetNonVisualPictureDrawingProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.NonVisualPictureDrawingProperties";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetNonVisualPictureDrawingProperties := DotNetNonVisualPictureDrawingProperties.NonVisualPictureDrawingProperties;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetNonVisualPictureDrawingProperties := DotNetNonVisualPictureDrawingProperties.NonVisualPictureDrawingProperties(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetNonVisualPictureDrawingProperties.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetNonVisualPictureDrawingProperties.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetPreferRelativeResize@17024416(NewPreferRelativeResize@17024401 : Boolean);
+    VAR
+      DotNetBooleanValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.BooleanValue";
+    BEGIN
+      DotNetNonVisualPictureDrawingProperties.PreferRelativeResize := DotNetBooleanValue.FromBoolean(NewPreferRelativeResize);
+    END;
+
+    PROCEDURE SetNonVisualPictureDrawingProperties@17024411(NewDotNetNonVisualPictureDrawingProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.NonVisualPictureDrawingProperties");
+    BEGIN
+      DotNetNonVisualPictureDrawingProperties := NewDotNetNonVisualPictureDrawingProperties;
+    END;
+
+    PROCEDURE GetNonVisualPictureDrawingProperties@17024400(VAR CurrentDotNetNonVisualPictureDrawingProperties@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Pictures.NonVisualPictureDrawingProperties");
+    BEGIN
+      CurrentDotNetNonVisualPictureDrawingProperties := DotNetNonVisualPictureDrawingProperties;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50057.TXT
+++ b/BaseApp/COD50057.TXT
@@ -1,0 +1,89 @@
+OBJECT Codeunit 50057 DotNet_Word.Blip
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetBlip@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Blip";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetBlip := DotNetBlip.Blip;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetBlip := DotNetBlip.Blip(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetBlip.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetBlip.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetEmbed@17024416(NewEmbed@17024401 : Text);
+    VAR
+      DotNetStringValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetBlip.Embed := DotNetStringValue.FromString(NewEmbed);
+    END;
+
+    [External]
+    PROCEDURE SetCompressionState@17024401(NewCompressionState@17024401 : 'Email,Screen,Print,HighQualityPrint,None');
+    VAR
+      DotNetBlipCompressionValues@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.BlipCompressionValues";
+      DotNetEnumValue@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.EnumValue`1";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.CreateEnumValueGeneric(GETDOTNETTYPE(DotNetBlipCompressionValues), NewCompressionState, DotNetEnumValue);
+      DotNetBlip.CompressionState := DotNetEnumValue;
+    END;
+
+    [External]
+    PROCEDURE AppendBlipExtensionList@17024404(VAR WordBlipExtensionList@17024401 : Codeunit 50059);
+    VAR
+      DotNetBlipExtensionList@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.BlipExtensionList";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      WordBlipExtensionList.GetBlipExtensionList(DotNetBlipExtensionList);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetBlip, DotNetBlipExtensionList);
+    END;
+
+    PROCEDURE SetBlip@17024411(NewDotNetBlip@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Blip");
+    BEGIN
+      DotNetBlip := NewDotNetBlip;
+    END;
+
+    PROCEDURE GetBlip@17024400(VAR CurrentDotNetBlip@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Blip");
+    BEGIN
+      CurrentDotNetBlip := DotNetBlip;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50058.TXT
+++ b/BaseApp/COD50058.TXT
@@ -1,0 +1,68 @@
+OBJECT Codeunit 50058 DotNet_Word.Stretch
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetStretch@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Stretch";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetStretch := DotNetStretch.Stretch;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetStretch := DotNetStretch.Stretch(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetStretch.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetStretch.InnerText);
+    END;
+
+    [External]
+    PROCEDURE AppendFillRectangle@17024416();
+    VAR
+      DotNetFillRectangle@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.FillRectangle";
+      OpenXmlDotNetHelper@17024401 : Codeunit 50067;
+    BEGIN
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetStretch, DotNetFillRectangle.FillRectangle);
+    END;
+
+    PROCEDURE SetStretch@17024411(NewDotNetStretch@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Stretch");
+    BEGIN
+      DotNetStretch := NewDotNetStretch;
+    END;
+
+    PROCEDURE GetStretch@17024400(VAR CurrentDotNetStretch@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Stretch");
+    BEGIN
+      CurrentDotNetStretch := DotNetStretch;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50059.TXT
+++ b/BaseApp/COD50059.TXT
@@ -1,0 +1,71 @@
+OBJECT Codeunit 50059 DotNet_Word.BlipExtensionList
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetBlipExtensionList@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.BlipExtensionList";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetBlipExtensionList := DotNetBlipExtensionList.BlipExtensionList;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetBlipExtensionList := DotNetBlipExtensionList.BlipExtensionList(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetBlipExtensionList.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetBlipExtensionList.InnerText);
+    END;
+
+    [External]
+    PROCEDURE AppendBlipExtension@17024416(Uri@17024401 : Text);
+    VAR
+      DotNetStringValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+      DotNetBlipExtension@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.BlipExtension";
+      OpenXmlDotNetHelper@17024403 : Codeunit 50067;
+    BEGIN
+      DotNetBlipExtension := DotNetBlipExtension.BlipExtension;
+      DotNetBlipExtension.Uri := DotNetStringValue.FromString(Uri);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetBlipExtensionList, DotNetBlipExtension);
+    END;
+
+    PROCEDURE SetBlipExtensionList@17024411(NewDotNetBlipExtensionList@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.BlipExtensionList");
+    BEGIN
+      DotNetBlipExtensionList := NewDotNetBlipExtensionList;
+    END;
+
+    PROCEDURE GetBlipExtensionList@17024400(VAR CurrentDotNetBlipExtensionList@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.BlipExtensionList");
+    BEGIN
+      CurrentDotNetBlipExtensionList := DotNetBlipExtensionList;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50060.TXT
+++ b/BaseApp/COD50060.TXT
@@ -1,0 +1,109 @@
+OBJECT Codeunit 50060 DotNet_Word.Transform2D
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetTransform2D@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Transform2D";
+      OpenXmlDotNetHelper@17024401 : Codeunit 50067;
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetTransform2D := DotNetTransform2D.Transform2D;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetTransform2D := DotNetTransform2D.Transform2D;
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024406() : Text;
+    BEGIN
+      EXIT(DotNetTransform2D.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024402() : Text;
+    BEGIN
+      EXIT(DotNetTransform2D.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetHorizontalFlip@17024401(NewHorizontalFlip@17024401 : Boolean);
+    VAR
+      DotNetBooleanValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.BooleanValue";
+    BEGIN
+      DotNetTransform2D.HorizontalFlip := DotNetBooleanValue.FromBoolean(NewHorizontalFlip);
+    END;
+
+    [External]
+    PROCEDURE SetVerticallFlip@17024404(NewVerticalFlip@17024401 : Boolean);
+    VAR
+      DotNetBooleanValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.BooleanValue";
+    BEGIN
+      DotNetTransform2D.VerticalFlip := DotNetBooleanValue.FromBoolean(NewVerticalFlip);
+    END;
+
+    [External]
+    PROCEDURE SetRotation@17024417(NewRotation@17024401 : Integer);
+    VAR
+      DotNetUInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.UInt32Value";
+    BEGIN
+      DotNetTransform2D.Rotation := DotNetUInt32Value.FromUInt32(NewRotation);
+    END;
+
+    [External]
+    PROCEDURE AppendExtent@17024410(Cx@17024401 : Integer;Cy@17024402 : Integer);
+    VAR
+      DotNetInt64Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Int64Value";
+      DotNetExtent@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Extents";
+    BEGIN
+      DotNetExtent := DotNetExtent.Extents;
+      DotNetExtent.Cx := DotNetInt64Value.FromInt64(Cx);
+      DotNetExtent.Cy := DotNetInt64Value.FromInt64(Cy);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetTransform2D, DotNetExtent);
+    END;
+
+    [External]
+    PROCEDURE AppendOffset@17024405(X@17024401 : Integer;Y@17024402 : Integer);
+    VAR
+      DotNetInt64Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Int64Value";
+      DotNetOffset@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Offset";
+    BEGIN
+      DotNetOffset := DotNetOffset.Offset;
+      DotNetOffset.X := DotNetInt64Value.FromInt64(X);
+      DotNetOffset.Y := DotNetInt64Value.FromInt64(Y);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetTransform2D, DotNetOffset);
+    END;
+
+    PROCEDURE SetTransform2D@17024411(NewDotNetTransform2D@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Transform2D");
+    BEGIN
+      DotNetTransform2D := NewDotNetTransform2D;
+    END;
+
+    PROCEDURE GetTransform2D@17024400(VAR CurrentDotNetTransform2D@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.Transform2D");
+    BEGIN
+      CurrentDotNetTransform2D := DotNetTransform2D;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50061.TXT
+++ b/BaseApp/COD50061.TXT
@@ -1,0 +1,80 @@
+OBJECT Codeunit 50061 DotNet_Word.PresetGeometry
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetPresetGeometry@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.PresetGeometry";
+      OpenXmlDotNetHelper@17024401 : Codeunit 50067;
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetPresetGeometry := DotNetPresetGeometry.PresetGeometry;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetPresetGeometry := DotNetPresetGeometry.PresetGeometry(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetPresetGeometry.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetPresetGeometry.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetPreset@17024416(NewPresetType@17024401 : Integer);
+    VAR
+      DotNetShapeTypeValues@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.ShapeTypeValues";
+      DotNetEnumValue@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.EnumValue`1";
+    BEGIN
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.CreateEnumValueGeneric(GETDOTNETTYPE(DotNetShapeTypeValues), NewPresetType, DotNetEnumValue);
+      DotNetPresetGeometry.Preset := DotNetEnumValue;
+    END;
+
+    [External]
+    PROCEDURE AppendAdjustValueList@17024404();
+    VAR
+      DotNetAdjustValueList@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.AdjustValueList";
+    BEGIN
+      DotNetAdjustValueList := DotNetAdjustValueList.AdjustValueList;
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetPresetGeometry, DotNetAdjustValueList);
+    END;
+
+    PROCEDURE SetPresetGeometry@17024411(NewDotNetPresetGeometry@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.PresetGeometry");
+    BEGIN
+      DotNetPresetGeometry := NewDotNetPresetGeometry;
+    END;
+
+    PROCEDURE GetPresetGeometry@17024400(VAR CurrentDotNetPresetGeometry@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Drawing.PresetGeometry");
+    BEGIN
+      CurrentDotNetPresetGeometry := DotNetPresetGeometry;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50062.TXT
+++ b/BaseApp/COD50062.TXT
@@ -1,0 +1,52 @@
+OBJECT Codeunit 50062 DotNet_Word.ParagraphEnumerato
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+
+    PROCEDURE SetEnumerator@17024415(NewEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      DotNetEnumerator := NewEnumerator;
+    END;
+
+    PROCEDURE GetEnumerator@17024414(VAR CurrentEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      CurrentEnumerator := DotNetEnumerator;
+    END;
+
+    [External]
+    PROCEDURE Reset@17024401();
+    BEGIN
+      DotNetEnumerator.Reset;
+    END;
+
+    [External]
+    PROCEDURE MoveNext@17024402() : Boolean;
+    BEGIN
+      EXIT(DotNetEnumerator.MoveNext);
+    END;
+
+    [External]
+    PROCEDURE GetCurrent@17024403(VAR CurrentParagraph@17024400 : Codeunit 50022);
+    BEGIN
+      CurrentParagraph.SetParagraph(DotNetEnumerator.Current);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50063.TXT
+++ b/BaseApp/COD50063.TXT
@@ -1,0 +1,52 @@
+OBJECT Codeunit 50063 DotNet_Word.RunEnumerator
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+
+    PROCEDURE SetEnumerator@17024415(NewEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      DotNetEnumerator := NewEnumerator;
+    END;
+
+    PROCEDURE GetEnumerator@17024414(VAR CurrentEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      CurrentEnumerator := DotNetEnumerator;
+    END;
+
+    [External]
+    PROCEDURE Reset@17024401();
+    BEGIN
+      DotNetEnumerator.Reset;
+    END;
+
+    [External]
+    PROCEDURE MoveNext@17024402() : Boolean;
+    BEGIN
+      EXIT(DotNetEnumerator.MoveNext);
+    END;
+
+    [External]
+    PROCEDURE GetCurrent@17024403(VAR CurrentRun@17024400 : Codeunit 50023);
+    BEGIN
+      CurrentRun.SetRun(DotNetEnumerator.Current);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50064.TXT
+++ b/BaseApp/COD50064.TXT
@@ -1,0 +1,52 @@
+OBJECT Codeunit 50064 DotNet_Word.TableEnumerator
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+
+    PROCEDURE SetEnumerator@17024415(NewEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      DotNetEnumerator := NewEnumerator;
+    END;
+
+    PROCEDURE GetEnumerator@17024414(VAR CurrentEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      CurrentEnumerator := DotNetEnumerator;
+    END;
+
+    [External]
+    PROCEDURE Reset@17024401();
+    BEGIN
+      DotNetEnumerator.Reset;
+    END;
+
+    [External]
+    PROCEDURE MoveNext@17024402() : Boolean;
+    BEGIN
+      EXIT(DotNetEnumerator.MoveNext);
+    END;
+
+    [External]
+    PROCEDURE GetCurrent@17024403(VAR CurrentTable@17024400 : Codeunit 50027);
+    BEGIN
+      CurrentTable.SetTable(DotNetEnumerator.Current);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50065.TXT
+++ b/BaseApp/COD50065.TXT
@@ -1,0 +1,52 @@
+OBJECT Codeunit 50065 DotNet_Word.TableRowEnumerator
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+
+    PROCEDURE SetEnumerator@17024415(NewEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      DotNetEnumerator := NewEnumerator;
+    END;
+
+    PROCEDURE GetEnumerator@17024414(VAR CurrentEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      CurrentEnumerator := DotNetEnumerator;
+    END;
+
+    [External]
+    PROCEDURE Reset@17024401();
+    BEGIN
+      DotNetEnumerator.Reset;
+    END;
+
+    [External]
+    PROCEDURE MoveNext@17024402() : Boolean;
+    BEGIN
+      EXIT(DotNetEnumerator.MoveNext);
+    END;
+
+    [External]
+    PROCEDURE GetCurrent@17024403(VAR CurrentTableRow@17024400 : Codeunit 50028);
+    BEGIN
+      CurrentTableRow.SetTableRow(DotNetEnumerator.Current);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50066.TXT
+++ b/BaseApp/COD50066.TXT
@@ -1,0 +1,52 @@
+OBJECT Codeunit 50066 DotNet_Word.TableCellEnumerato
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+
+    PROCEDURE SetEnumerator@17024415(NewEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      DotNetEnumerator := NewEnumerator;
+    END;
+
+    PROCEDURE GetEnumerator@17024414(VAR CurrentEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      CurrentEnumerator := DotNetEnumerator;
+    END;
+
+    [External]
+    PROCEDURE Reset@17024401();
+    BEGIN
+      DotNetEnumerator.Reset;
+    END;
+
+    [External]
+    PROCEDURE MoveNext@17024402() : Boolean;
+    BEGIN
+      EXIT(DotNetEnumerator.MoveNext);
+    END;
+
+    [External]
+    PROCEDURE GetCurrent@17024403(VAR CurrentTableCell@17024400 : Codeunit 50029);
+    BEGIN
+      CurrentTableCell.SetTableCell(DotNetEnumerator.Current);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50067.TXT
+++ b/BaseApp/COD50067.TXT
@@ -1,0 +1,111 @@
+OBJECT Codeunit 50067 OpenXml DotNet Helper
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+
+    PROCEDURE CreateEnumValueGeneric@17024403(DotNetEnumType@17024401 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Type";IntegerValue@17024402 : Integer;VAR CreatedDotNetEnumValue@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.EnumValue`1");
+    VAR
+      DotNetEnum@17024403 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Enum";
+      DotNetType@17024407 : DotNet "'mscorlib'.System.Type";
+      DotNetObject@17024406 : DotNet "'mscorlib'.System.Object";
+      DotNetTypeArray@17024405 : DotNet "'mscorlib'.System.Array";
+      DotNetParamsArray@17024404 : DotNet "'mscorlib'.System.Array";
+    BEGIN
+      //Must never be made External. Used only internally
+
+      //This ugly code below is in fact
+      //CreatedDotNetEnumValue = new OpenXmlEnum<DotNetEnumType>(IntegerValue)
+      //But since generics are not supported we get this:
+      DotNetType := GETDOTNETTYPE(CreatedDotNetEnumValue);
+      DotNetTypeArray := DotNetTypeArray.CreateInstance(GETDOTNETTYPE(DotNetType), 1);
+      DotNetTypeArray.SetValue(DotNetEnumType, 0);
+      DotNetType := DotNetType.MakeGenericType(DotNetTypeArray);
+      DotNetTypeArray := DotNetTypeArray.CreateInstance(GETDOTNETTYPE(DotNetType), 0);
+      DotNetParamsArray := DotNetParamsArray.CreateInstance(GETDOTNETTYPE(DotNetObject), 0);
+      CreatedDotNetEnumValue := DotNetType.GetConstructor(DotNetTypeArray).Invoke(DotNetParamsArray);
+      CreatedDotNetEnumValue.Value := DotNetEnum.GetValues(DotNetEnumType).GetValue(IntegerValue);
+    END;
+
+    [Internal]
+    PROCEDURE GetEnumeratorOfTypeGeneric@17024402(OriginalOpenXmlElementList@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.OpenXmlElementList";FilterType@17024401 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Type";VAR FilteredDotNetEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    VAR
+      FilteredDotNetEnumerable@17024403 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerable";
+    BEGIN
+      //Must never be made External. Used only internally
+      //Helper for calling method: IEnumerator OpenXmlElement.OfType<T>()
+      OfType(OriginalOpenXmlElementList, FilterType, FilteredDotNetEnumerable);
+      FilteredDotNetEnumerator := FilteredDotNetEnumerable.GetEnumerator;
+    END;
+
+    PROCEDURE AppendGeneric@17024400(DotNetParent@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.OpenXmlElement";DotNetChild@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.OpenXmlElement");
+    VAR
+      DotNetArray@17024402 : DotNet "'mscorlib'.System.Array";
+    BEGIN
+      //Must never be made External. Used only internally
+      //Helper for calling method: void OpenXmlElement.Append(params OpenXmlElement[] childs)
+      DotNetArray := DotNetArray.CreateInstance(GETDOTNETTYPE(DotNetChild), 1);
+      DotNetArray.SetValue(DotNetChild, 0);
+      DotNetParent.Append(DotNetArray);
+    END;
+
+    PROCEDURE AddPartGeneric@17024409(VAR DotNetMainDocumentPart@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.MainDocumentPart";DotNetPartType@17024408 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Type";VAR DotNetCreatedPart@17024407 : DotNet "'mscorlib'.System.Object");
+    VAR
+      DotNetNumberingDefinitionsPart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.NumberingDefinitionsPart";
+      DotNetType@17024406 : DotNet "'mscorlib'.System.Type";
+      DotNetObject@17024405 : DotNet "'mscorlib'.System.Object";
+      DotNetTypeArrayForGenericTypeResolution@17024404 : DotNet "'mscorlib'.System.Array";
+      DotNetTypeArrayForMethodLookup@17024403 : DotNet "'mscorlib'.System.Array";
+      DotNetParamsArray@17024401 : DotNet "'mscorlib'.System.Array";
+    BEGIN
+      //Must never be made External. Used only internally
+      //Normally is should have been something as simple as:
+      //DotNetCreatedPart := DotNetMainDocumentPart.AddNewPart<DotNetPartType>();
+      //But since NAV have no such thing as generics support, I need to fallback to reflection calls:
+      //C# view: Type[] DotNetTypeArray = new Type[] { typeof(DotNetPartType) };
+      DotNetTypeArrayForGenericTypeResolution := DotNetTypeArrayForGenericTypeResolution.CreateInstance(GETDOTNETTYPE(DotNetType), 1);
+      DotNetTypeArrayForGenericTypeResolution.SetValue(DotNetPartType, 0);
+      DotNetTypeArrayForMethodLookup := DotNetTypeArrayForMethodLookup.CreateInstance(GETDOTNETTYPE(DotNetType), 0);
+      //C# view: Object[] DotNetParamsArray = new Object[] {};
+      DotNetParamsArray := DotNetParamsArray.CreateInstance(GETDOTNETTYPE(DotNetObject), 0);
+
+      DotNetType := GETDOTNETTYPE(DotNetMainDocumentPart);
+      DotNetCreatedPart := DotNetType.GetMethod('AddNewPart', DotNetTypeArrayForMethodLookup).MakeGenericMethod(DotNetTypeArrayForGenericTypeResolution).Invoke(DotNetMainDocumentPart, DotNetParamsArray);
+    END;
+
+    LOCAL PROCEDURE OfType@17024401(OriginalOpenXmlElementList@17024404 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.OpenXmlElementList";FilterType@17024402 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Type";VAR FilteredDotNetEnumerable@17024401 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerable");
+    VAR
+      EnumerableType@17024403 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Type";
+      DotNetObject@17024400 : DotNet "'mscorlib'.System.Object";
+      DotNetTypeArray@17024407 : DotNet "'mscorlib'.System.Array";
+      DotNetParamsArray@17024406 : DotNet "'mscorlib'.System.Array";
+    BEGIN
+      //Normally is should have been something as simple as:
+      //FilteredDotNetEnumerable = OriginalOpenXmlElementList.OfType<FilteredType>();
+      //But since NAV have no such thing as generics support, I need to fallback to reflection calls:
+      //C# view: Type[] DotNetTypeArray = new Type[] { typeof(DotNetStyleDefinitionsPart) };
+      DotNetTypeArray := DotNetTypeArray.CreateInstance(GETDOTNETTYPE(FilterType), 1);
+      DotNetTypeArray.SetValue(FilterType, 0);
+      //C# view: Object[] DotNetParamsArray = new Object[] {};
+      DotNetParamsArray := DotNetParamsArray.CreateInstance(GETDOTNETTYPE(DotNetObject), 0);
+      EnumerableType := GETDOTNETTYPE(OriginalOpenXmlElementList);
+      //C# view: FilteredDotNetEnumerable = OriginalOpenXmlElementList.OfType<FilteredType>()
+      FilteredDotNetEnumerable := EnumerableType.GetMethod('OfType').MakeGenericMethod(DotNetTypeArray).Invoke(OriginalOpenXmlElementList, DotNetParamsArray);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50068.TXT
+++ b/BaseApp/COD50068.TXT
@@ -1,0 +1,391 @@
+OBJECT Codeunit 50068 OpenXml WordProcessing Helper
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+
+    [External]
+    PROCEDURE CloneStyleRunProperties@17024400(VAR OriginalWordStyleRunProperties@17024400 : Codeunit 50037;VAR ClonedWordStyleRunProperties@17024401 : Codeunit 50037);
+    BEGIN
+      ClonedWordStyleRunProperties.CreateFromOuterXml(OriginalWordStyleRunProperties.GetOuterXml);
+    END;
+
+    [External]
+    PROCEDURE CloneParagraphProperties@17024403(VAR OriginalWordParagraphProperties@17024400 : Codeunit 50026;VAR ClonedWordParagraphProperties@17024401 : Codeunit 50026);
+    BEGIN
+      ClonedWordParagraphProperties.CreateFromOuterXml(OriginalWordParagraphProperties.GetOuterXml);
+    END;
+
+    [External]
+    PROCEDURE CreateEmptyDocument@17024402(DocumentType@17024401 : 'Document,Template,MacroEnabledDocument,MacroEnabledTemplate';VAR CreatedWordprocessingDocument@17024400 : Codeunit 50018;VAR MainDocumentPart@17024402 : Codeunit 50019;VAR WordBody@17024404 : Codeunit 50021);
+    VAR
+      WordDocument@17024403 : Codeunit 50020;
+    BEGIN
+      //Helper for creating an empty document and initiating required parts
+      CreatedWordprocessingDocument.Create(DocumentType, TRUE);
+      CreatedWordprocessingDocument.AddMainDocumentPart(MainDocumentPart);
+      WordDocument.Create;
+      MainDocumentPart.SetDocument(WordDocument);
+      WordBody.Create;
+      WordDocument.SetBody(WordBody);
+    END;
+
+    [External]
+    PROCEDURE CreateHyperLink@17024401(Url@17024400 : Text;TextValue@17024401 : Text;VAR MainDocumentPart@17024402 : Codeunit 50019;VAR CreatedWordHyperlink@17024403 : Codeunit 50035) : Text;
+    VAR
+      HyperlinkRelationship@17024404 : Codeunit 50034;
+      HrContactId@17024405 : Text;
+      WordProofError@17024406 : Codeunit 50033;
+      WordRunProperties@17024407 : Codeunit 50025;
+      WordColor@17024408 : Codeunit 50036;
+      WordText@17024409 : Codeunit 50024;
+      WordRun@17024410 : Codeunit 50023;
+    BEGIN
+      //Helper for creating new hyperlink element
+      MainDocumentPart.AddHyperlinkRelationship(Url, TRUE, HyperlinkRelationship);
+      HrContactId := HyperlinkRelationship.GetId;
+      WordProofError.Create;
+      WordProofError.SetType(2); //Type = GrammarStart
+      WordRunProperties.Create;
+      WordRunProperties.SetRunStyle('Hyperlink');
+      WordColor.Create;
+      WordColor.SetColorTheme(10); //Theme = Hyperlink
+      WordRunProperties.SetColor(WordColor);
+      WordText.Create;
+      WordText.SetText(TextValue);
+      WordText.SetSpacePreserveOption(TRUE);
+      WordRun.Create;
+      WordRun.AppendProperties(WordRunProperties);
+      WordRun.AppendText(WordText);
+      CreatedWordHyperlink.Create;
+      CreatedWordHyperlink.SetId(HrContactId);
+      CreatedWordHyperlink.SetHistory(TRUE);
+      CreatedWordHyperlink.AppendProofError(WordProofError);
+      CreatedWordHyperlink.AppendRun(WordRun);
+      EXIT(HrContactId);
+    END;
+
+    [External]
+    PROCEDURE AddParagraphStyleToDocument@17024409(VAR MainDocumentPart@17024403 : Codeunit 50019;StyleId@17024402 : Text;StyleName@17024401 : Text;VAR WordStyleRunProperties@17024400 : Codeunit 50037) ActualStyleId : Text;
+    VAR
+      WordStyleDefinitionPart@17024405 : Codeunit 50041;
+      StyleIdFromName@17024404 : Text;
+      WordStyles@17024406 : Codeunit 50039;
+    BEGIN
+      //Helper for adding new paragraph style
+      //Based on: https://msdn.microsoft.com/en-us/library/cc850838.aspx
+      IF NOT MainDocumentPart.HasStyleDefinitionsPart THEN
+        BEGIN
+          MainDocumentPart.AddStyleDefinitionsPart(WordStyleDefinitionPart);
+          WordStyles.Create;
+          WordStyleDefinitionPart.SetStyles(WordStyles);
+        END
+      ELSE
+        MainDocumentPart.GetStyleDefinitionsPart(WordStyleDefinitionPart);
+
+      IF NOT IsParagraphStyleIdInDocument(WordStyleDefinitionPart, StyleId) THEN
+        BEGIN
+          StyleIdFromName := GetParagraphStyleIdFromStyleName(WordStyleDefinitionPart, StyleName);
+          IF StyleIdFromName = '' THEN
+            AddNewParagraphStyle(WordStyleDefinitionPart, StyleId, StyleName, WordStyleRunProperties)
+          ELSE
+            StyleId := StyleIdFromName;
+        END;
+
+      EXIT(StyleId);
+    END;
+
+    [External]
+    PROCEDURE AddNumberingTypeToDocument@17024407(VAR MainDocumentPart@17024403 : Codeunit 50019;NumberingId@17024402 : Integer;FormatType@17024401 : Integer;FormatText@17024400 : Text);
+    VAR
+      WordNumberingDefinitionsPart@17024405 : Codeunit 50070;
+      WordNumbering@17024406 : Codeunit 50071;
+    BEGIN
+      //Helper for adding new numbering type
+      IF NOT MainDocumentPart.HasNumberingDefinitionsPart THEN
+        BEGIN
+          MainDocumentPart.AddNumberingDefinitionsPart(WordNumberingDefinitionsPart);
+          WordNumbering.Create;
+          WordNumberingDefinitionsPart.SetNumbering(WordNumbering);
+        END
+      ELSE
+        MainDocumentPart.GetNumberingDefinitionsPart(WordNumberingDefinitionsPart);
+
+
+      IF NOT IsNumberingTypeIdInDocument(WordNumberingDefinitionsPart, NumberingId) THEN
+        AddNewNumberingType(WordNumberingDefinitionsPart, NumberingId, FormatType, FormatText);
+    END;
+
+    [External]
+    PROCEDURE CreateBulletListProperties@17024408(VAR MainDocumentPart@17024400 : Codeunit 50019;VAR WordParagraphProperties@17024403 : Codeunit 50026;LeftIndentation@17024402 : Text);
+    BEGIN
+      //Helper for creating bullet list paragraph properties
+      AddNumberingTypeToDocument(MainDocumentPart, 0, 23, 'o');
+      CreateParagraphPropertiesForList(WordParagraphProperties, LeftIndentation, 0, 1);
+    END;
+
+    [External]
+    PROCEDURE CreateOrderedListProperties@17024411(VAR MainDocumentPart@17024400 : Codeunit 50019;VAR WordParagraphProperties@17024403 : Codeunit 50026;LeftIndentation@17024402 : Text);
+    BEGIN
+      //Helper for creating ordered list paragraph properties
+      AddNumberingTypeToDocument(MainDocumentPart, 1, 0, '%1.');
+      CreateParagraphPropertiesForList(WordParagraphProperties, LeftIndentation, 0, 2);
+    END;
+
+    [External]
+    PROCEDURE CreateDrawingFromStream@17024425(VAR MainDocumentPart@17024400 : Codeunit 50019;ImagePartType@17024405 : 'Bmp,Gif,Png,Tiff,Icon,Pcx,Jpeg,Emf,Wmf';ImageStream@17024401 : InStream;Name@17024402 : Text;Width@17024403 : Integer;Height@17024404 : Integer;VAR CreatedWordDrawing@17024408 : Codeunit 50043) : Text;
+    VAR
+      WordImagePart@17024406 : Codeunit 50042;
+      RelationshipId@17024407 : Text;
+    BEGIN
+      //Helper for adding picture from stream to document
+      //Based on: https://msdn.microsoft.com/en-us/library/office/bb497430.aspx
+      MainDocumentPart.AddImagePart(ImagePartType, WordImagePart);
+      WordImagePart.FeedData(ImageStream);
+      RelationshipId := MainDocumentPart.GetIdOfImagePart(WordImagePart);
+      CreateDrawing(RelationshipId, Name + '.' + FORMAT(ImagePartType), Width, Height, '', CreatedWordDrawing);
+      EXIT(RelationshipId);
+    END;
+
+    LOCAL PROCEDURE CreateDrawing@17024414(RelationshipId@17024400 : Text;Name@17024401 : Text;Cx@17024402 : Integer;Cy@17024403 : Integer;Position@17024404 : Text;VAR CreatedWordDrawing@17024405 : Codeunit 50043);
+    VAR
+      WordAnchor@17024406 : Codeunit 50044;
+      ActualPosition@17024407 : Text;
+      WordHorizontalPosition@17024408 : Codeunit 50046;
+      WordVerticalPosition@17024409 : Codeunit 50045;
+      WordWrapSquare@17024410 : Codeunit 50047;
+      WordWrapTopBottom@17024411 : Codeunit 50048;
+      WordDocProperties@17024412 : Codeunit 50049;
+      WordGraphicFrameLocks@17024413 : Codeunit 50050;
+      WordPicture@17024414 : Codeunit 50051;
+    BEGIN
+      ActualPosition := Position;
+      IF ActualPosition = '' THEN
+        ActualPosition := 'left';
+
+      WordAnchor.Create;
+      WordAnchor.AppendSimplePosition(0, 0);
+      WordHorizontalPosition.Create;
+      WordHorizontalPosition.SetRelativeFrom(0); //Type = Margin
+      WordHorizontalPosition.SetHorizontalAlignment(ActualPosition);
+      WordAnchor.AppendHorizontalPosition(WordHorizontalPosition);
+      WordVerticalPosition.Create;
+      WordVerticalPosition.SetPositionOffset('0');
+      WordVerticalPosition.SetRelativeFrom(2); // Type = Paragraph
+      WordAnchor.AppendVerticalPosition(WordVerticalPosition);
+      WordAnchor.AppendExtent(Cx, Cy);
+      WordAnchor.AppendEffectExtent(0, 0, 0, 0);
+      IF Position <> '' THEN
+        BEGIN
+          WordWrapSquare.Create;
+          WordWrapSquare.SetWrapText(0); // Type = BothSides
+          WordAnchor.AppendWrapSquare(WordWrapSquare);
+        END
+      ELSE
+        BEGIN
+          WordWrapTopBottom.Create;
+          WordAnchor.AppendWrapTopBottom(WordWrapTopBottom);
+        END;
+
+      WordDocProperties.Create;
+      WordDocProperties.SetId(1);
+      WordDocProperties.SetName(Name);
+      WordAnchor.AppendDocProperties(WordDocProperties);
+      WordGraphicFrameLocks.Create;
+      WordGraphicFrameLocks.SetNoChangeAspect(TRUE);
+      WordAnchor.AppendGraphicFrameLocks(WordGraphicFrameLocks);
+      CreatePicture(RelationshipId, Name, Cx, Cy, WordPicture);
+      WordAnchor.AppendPicture(WordPicture);
+      WordAnchor.SetDistanceFromTop(0);
+      WordAnchor.SetDistanceFromBottom(0);
+      WordAnchor.SetDistanceFromLeft(114300);
+      WordAnchor.SetDistanceFromRight(114300);
+      WordAnchor.SetSimplePos(FALSE);
+      WordAnchor.SetRelativeHeight(251658240);
+      WordAnchor.SetBehindDoc(TRUE);
+      WordAnchor.SetLocked(FALSE);
+      WordAnchor.SetLayoutInCell(TRUE);
+      WordAnchor.SetAllowOverlap(TRUE);
+      CreatedWordDrawing.Create;
+      CreatedWordDrawing.AppendAnchor(WordAnchor);
+    END;
+
+    LOCAL PROCEDURE CreatePicture@17024418(RelationshipId@17024413 : Text;Name@17024409 : Text;Cx@17024406 : Integer;Cy@17024407 : Integer;VAR WordPicture@17024400 : Codeunit 50051);
+    VAR
+      WordBlipFill@17024401 : Codeunit 50054;
+      WordShapeProperties@17024402 : Codeunit 50053;
+      WordNonVisualPictureProperties@17024403 : Codeunit 50052;
+      WordPresetGeometry@17024404 : Codeunit 50061;
+      WordTransform2D@17024405 : Codeunit 50060;
+      WordNonVisualDrawingProperties@17024408 : Codeunit 50055;
+      WordNonVisualPictureDrawingProperties@17024410 : Codeunit 50056;
+      WordBlip@17024411 : Codeunit 50057;
+      WordStretch@17024412 : Codeunit 50058;
+      WordBlipExtensionList@17024414 : Codeunit 50059;
+    BEGIN
+      WordPicture.Create;
+      WordBlipFill.Create;
+      WordBlip.Create;
+      WordBlip.SetEmbed(RelationshipId);
+      WordBlip.SetCompressionState(2); //Type = Print
+      WordBlipExtensionList.Create;
+      WordBlipExtensionList.AppendBlipExtension('{28A0092B-C50C-407E-A947-70E740481C1C}');
+      WordBlip.AppendBlipExtensionList(WordBlipExtensionList);
+      WordBlipFill.SetBlip(WordBlip);
+      WordStretch.Create;
+      WordStretch.AppendFillRectangle;
+      WordBlipFill.AppendStretch(WordStretch);
+      WordPicture.SetBlipFill(WordBlipFill);
+      WordNonVisualPictureProperties.Create;
+      WordNonVisualDrawingProperties.Create;
+      WordNonVisualDrawingProperties.SetId(0);
+      WordNonVisualDrawingProperties.SetName(Name);
+      WordNonVisualPictureProperties.SetNonVisualDrawingProperties(WordNonVisualDrawingProperties);
+      WordNonVisualPictureDrawingProperties.Create;
+      WordNonVisualPictureProperties.SetNonVisualPictureDrawingProperties(WordNonVisualPictureDrawingProperties);
+      WordPicture.SetNonVisualPictureProperties(WordNonVisualPictureProperties);
+      WordShapeProperties.Create;
+      WordPresetGeometry.Create;
+      WordPresetGeometry.AppendAdjustValueList;
+      WordPresetGeometry.SetPreset(4); //Type = Rectangle
+      WordShapeProperties.AppendPresetGeometry(WordPresetGeometry);
+      WordTransform2D.Create;
+      WordTransform2D.AppendOffset(0, 0);
+      WordTransform2D.AppendExtent(Cx, Cy);
+      WordShapeProperties.SetTransform2D(WordTransform2D);
+      WordPicture.SetShapeProperties(WordShapeProperties);
+    END;
+
+    LOCAL PROCEDURE AddNewParagraphStyle@17024404(VAR WordStyleDefinitionPart@17024400 : Codeunit 50041;StyleId@17024401 : Text;StyleName@17024402 : Text;VAR WordStyleRunProperties@17024403 : Codeunit 50037);
+    VAR
+      WordStyles@17024404 : Codeunit 50039;
+      WordStyle@17024405 : Codeunit 50038;
+      ClonedWordStyleRunProperties@17024406 : Codeunit 50037;
+    BEGIN
+      WordStyleDefinitionPart.GetStyles(WordStyles);
+      WordStyle.Create;
+      WordStyle.SetStyleType(0); //Type = Paragraph
+      WordStyle.SetStyleId(StyleId);
+      WordStyle.SetCustomStyle(TRUE);
+      WordStyle.SetStyleName(StyleName);
+      WordStyle.SetBasedOn('Normal');
+      WordStyle.SetNextParagraphStyle('Normal');
+      WordStyle.SetUIPriority(900);
+      CloneStyleRunProperties(WordStyleRunProperties, ClonedWordStyleRunProperties);
+      WordStyle.AppendStyleRunProperties(ClonedWordStyleRunProperties);
+      WordStyles.AppendStyle(WordStyle);
+    END;
+
+    LOCAL PROCEDURE AddNewNumberingType@17024412(VAR WordNumberingDefinitionPart@17024400 : Codeunit 50070;Id@17024401 : Integer;Type@17024402 : Integer;Text@17024407 : Text);
+    VAR
+      WordNumbering@17024404 : Codeunit 50071;
+      WordAbstractNum@17024405 : Codeunit 50072;
+      WordNumberingLevel@17024403 : Codeunit 50073;
+      WordNumberingInstance@17024406 : Codeunit 50074;
+    BEGIN
+      WordNumberingDefinitionPart.GetNumbering(WordNumbering);
+      WordAbstractNum.Create;
+      WordAbstractNum.SetAbstractNumberId(Id);
+      WordNumberingLevel.Create;
+      WordNumberingLevel.SetLevelIndex(0);
+      WordNumberingLevel.SetNumberingFormatType(Type);
+      WordNumberingLevel.SetLevelText(Text);
+      WordAbstractNum.AppendLevel(WordNumberingLevel);
+      WordNumbering.AppendAbstractNum(WordAbstractNum);
+      WordNumberingInstance.Create;
+      WordNumberingInstance.SetAbstractNumId(Id);
+      WordNumberingInstance.SetNumberID(Id + 1);
+      WordNumbering.AppendNumberingInstance(WordNumberingInstance);
+    END;
+
+    LOCAL PROCEDURE CreateParagraphPropertiesForList@17024413(VAR WordParagraphProperties@17024400 : Codeunit 50026;LeftIndentation@17024404 : Text;NumberingLevelReference@17024405 : Integer;NumberingId@17024406 : Integer);
+    VAR
+      WordSpacingBetweenLines@17024401 : Codeunit 50030;
+      WordIndentation@17024402 : Codeunit 50031;
+      WordNumberingProperties@17024403 : Codeunit 50032;
+    BEGIN
+      WordParagraphProperties.Create;
+      WordSpacingBetweenLines.Create;
+      WordSpacingBetweenLines.SetAfter('0');
+      WordParagraphProperties.SetSpacingBetweenLines(WordSpacingBetweenLines);
+      WordIndentation.Create;
+      WordIndentation.SetLeft(LeftIndentation);
+      WordIndentation.SetHanging('360');
+      WordParagraphProperties.SetIndentation(WordIndentation);
+      WordNumberingProperties.Create;
+      WordNumberingProperties.SetNumberingId(NumberingId);
+      WordNumberingProperties.SetNumberingLevelReference(NumberingLevelReference);
+      WordParagraphProperties.SetNumberingProperties(WordNumberingProperties);
+      WordParagraphProperties.SetParagraphStyleId('ListParagraph');
+    END;
+
+    LOCAL PROCEDURE IsParagraphStyleIdInDocument@17024405(VAR WordStyleDefinitionPart@17024400 : Codeunit 50041;StyleId@17024401 : Text) : Boolean;
+    VAR
+      WordStyles@17024403 : Codeunit 50039;
+      WordStyle@17024404 : Codeunit 50038;
+      WordStylesEnumerator@17024405 : Codeunit 50040;
+    BEGIN
+      WordStyleDefinitionPart.GetStyles(WordStyles);
+      WordStyles.GetStyleEnumerator(WordStylesEnumerator);
+      WHILE WordStylesEnumerator.MoveNext DO
+        BEGIN
+          WordStylesEnumerator.GetCurrent(WordStyle);
+          IF (WordStyle.GetStyleId = StyleId) AND (WordStyle.GetStyleType = 0) THEN //Type = Paragraph
+            EXIT(TRUE);
+        END;
+
+      EXIT(FALSE);
+    END;
+
+    LOCAL PROCEDURE GetParagraphStyleIdFromStyleName@17024406(VAR WordStyleDefinitionPart@17024400 : Codeunit 50041;StyleName@17024401 : Text) : Text;
+    VAR
+      WordStyles@17024404 : Codeunit 50039;
+      WordStyle@17024403 : Codeunit 50038;
+      WordStylesEnumerator@17024402 : Codeunit 50040;
+    BEGIN
+      WordStyleDefinitionPart.GetStyles(WordStyles);
+      WordStyles.GetStyleEnumerator(WordStylesEnumerator);
+      WHILE WordStylesEnumerator.MoveNext DO
+        BEGIN
+          WordStylesEnumerator.GetCurrent(WordStyle);
+          IF (WordStyle.GetStyleName = StyleName) AND (WordStyle.GetStyleType = 0) THEN //Type = Paragraph
+            EXIT(WordStyle.GetStyleId);
+        END;
+
+      EXIT('');
+    END;
+
+    LOCAL PROCEDURE IsNumberingTypeIdInDocument@17024410(VAR WordNumberingDefinitionPart@17024400 : Codeunit 50070;Id@17024401 : Integer) : Boolean;
+    VAR
+      WordNumbering@17024403 : Codeunit 50071;
+      WordAbstractNum@17024404 : Codeunit 50072;
+      WordAbstractNumEnumerator@17024405 : Codeunit 50075;
+    BEGIN
+      WordNumberingDefinitionPart.GetNumbering(WordNumbering);
+      WordNumbering.GetAbstractNumEnumerator(WordAbstractNumEnumerator);
+      WHILE WordAbstractNumEnumerator.MoveNext DO
+        BEGIN
+          WordAbstractNumEnumerator.GetCurrent(WordAbstractNum);
+          IF WordAbstractNum.GetAbstractNumberId = Id THEN
+            EXIT(TRUE);
+        END;
+
+      EXIT(FALSE);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50070.TXT
+++ b/BaseApp/COD50070.TXT
@@ -1,0 +1,49 @@
+OBJECT Codeunit 50070 DotNet_Word.NumberingDefinitio
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetNumberingDefinitionsPart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.NumberingDefinitionsPart";
+
+    [External]
+    PROCEDURE SetNumbering@17024403(VAR WordNumbering@17024400 : Codeunit 50071);
+    VAR
+      DotNetNumbering@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Numbering";
+    BEGIN
+      WordNumbering.GetNumbering(DotNetNumbering);
+      DotNetNumberingDefinitionsPart.Numbering := DotNetNumbering;
+    END;
+
+    [External]
+    PROCEDURE GetNumbering@17024401(VAR WordNumbering@17024400 : Codeunit 50071);
+    BEGIN
+      WordNumbering.SetNumbering(DotNetNumberingDefinitionsPart.Numbering);
+    END;
+
+    PROCEDURE SetNumberingDefinitionsPart@17024411(NewDotNetNumberingDefinitionsPart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.NumberingDefinitionsPart");
+    BEGIN
+      DotNetNumberingDefinitionsPart := NewDotNetNumberingDefinitionsPart;
+    END;
+
+    PROCEDURE GetNumberingDefinitionsPart@17024400(VAR CurrentDotNetNumberingDefinitionsPart@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.NumberingDefinitionsPart");
+    BEGIN
+      CurrentDotNetNumberingDefinitionsPart := DotNetNumberingDefinitionsPart;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50071.TXT
+++ b/BaseApp/COD50071.TXT
@@ -1,0 +1,101 @@
+OBJECT Codeunit 50071 DotNet_Word.Numbering
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetNumbering@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Numbering";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetNumbering := DotNetNumbering.Numbering;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetNumbering := DotNetNumbering.Numbering(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024404() : Text;
+    BEGIN
+      EXIT(DotNetNumbering.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetNumbering.InnerText);
+    END;
+
+    [External]
+    PROCEDURE AppendAbstractNum@17024405(VAR WordAbstractNum@17024401 : Codeunit 50072);
+    VAR
+      DotNetAbstractNum@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.AbstractNum";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      WordAbstractNum.GetAbstractNum(DotNetAbstractNum);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetNumbering, DotNetAbstractNum);
+    END;
+
+    [External]
+    PROCEDURE AppendNumberingInstance@17024402(VAR WordNumberingInstance@17024401 : Codeunit 50074);
+    VAR
+      DotNetNumberingInstance@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.NumberingInstance";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      WordNumberingInstance.GetNumberingInstance(DotNetNumberingInstance);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetNumbering, DotNetNumberingInstance);
+    END;
+
+    [External]
+    PROCEDURE Save@17024401(VAR WordNumberingDefinitionPart@17024401 : Codeunit 50070);
+    VAR
+      DotNetNumberingDefinitionsPart@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Packaging.NumberingDefinitionsPart";
+    BEGIN
+      WordNumberingDefinitionPart.GetNumberingDefinitionsPart(DotNetNumberingDefinitionsPart);
+      DotNetNumbering.Save(DotNetNumberingDefinitionsPart);
+    END;
+
+    [External]
+    PROCEDURE GetAbstractNumEnumerator@17024413(VAR WordAbstractNumEnumerator@17024400 : Codeunit 50075);
+    VAR
+      DotNetAbstractNum@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.AbstractNum";
+      DotNetEnumerator@17024403 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+      OpenXmlDotNetHelper@17024401 : Codeunit 50067;
+    BEGIN
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.GetEnumeratorOfTypeGeneric(DotNetNumbering.Elements, GETDOTNETTYPE(DotNetAbstractNum), DotNetEnumerator);
+      WordAbstractNumEnumerator.SetEnumerator(DotNetEnumerator);
+    END;
+
+    PROCEDURE SetNumbering@17024411(NewDotNetNumbering@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Numbering");
+    BEGIN
+      DotNetNumbering := NewDotNetNumbering;
+    END;
+
+    PROCEDURE GetNumbering@17024400(VAR CurrentDotNetNumbering@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Numbering");
+    BEGIN
+      CurrentDotNetNumbering := DotNetNumbering;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50072.TXT
+++ b/BaseApp/COD50072.TXT
@@ -1,0 +1,83 @@
+OBJECT Codeunit 50072 DotNet_Word.AbstractNum
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetAbstractNum@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.AbstractNum";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetAbstractNum := DotNetAbstractNum.AbstractNum;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetAbstractNum := DotNetAbstractNum.AbstractNum(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024401() : Text;
+    BEGIN
+      EXIT(DotNetAbstractNum.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetAbstractNum.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetAbstractNumberId@17024404(NewNumId@17024401 : Integer);
+    VAR
+      DotNetInt32Value@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Int32Value";
+    BEGIN
+      DotNetAbstractNum.AbstractNumberId := DotNetInt32Value.FromInt32(NewNumId);
+    END;
+
+    [External]
+    PROCEDURE GetAbstractNumberId@17024415() : Integer;
+    BEGIN
+      EXIT(DotNetAbstractNum.AbstractNumberId.Value);
+    END;
+
+    [External]
+    PROCEDURE AppendLevel@17024402(VAR WordNumberingLevel@17024401 : Codeunit 50073);
+    VAR
+      DotNetLevel@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Level";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      WordNumberingLevel.GetLevel(DotNetLevel);
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.AppendGeneric(DotNetAbstractNum, DotNetLevel);
+    END;
+
+    PROCEDURE SetAbstractNum@17024411(NewDotNetAbstractNum@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.AbstractNum");
+    BEGIN
+      DotNetAbstractNum := NewDotNetAbstractNum;
+    END;
+
+    PROCEDURE GetAbstractNum@17024400(VAR CurrentDotNetAbstractNum@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.AbstractNum");
+    BEGIN
+      CurrentDotNetAbstractNum := DotNetAbstractNum;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50073.TXT
+++ b/BaseApp/COD50073.TXT
@@ -1,0 +1,103 @@
+OBJECT Codeunit 50073 DotNet_Word.NumberingLevel
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetLevel@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Level";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetLevel := DotNetLevel.Level;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024404(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetLevel := DotNetLevel.Level(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024402() : Text;
+    BEGIN
+      EXIT(DotNetLevel.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024401() : Text;
+    BEGIN
+      EXIT(DotNetLevel.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetLevelText@17024405(NewLevelText@17024401 : Text);
+    VAR
+      DotNetLevelText@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.LevelText";
+      DotNetStringValue@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.StringValue";
+    BEGIN
+      DotNetLevelText := DotNetLevelText.LevelText;
+      DotNetLevelText.Val := DotNetStringValue.FromString(NewLevelText);
+      DotNetLevel.LevelText := DotNetLevelText;
+    END;
+
+    [External]
+    PROCEDURE SetLevelIndex@17024406(NewLevelIndex@17024401 : Integer);
+    VAR
+      DotNetInt32Value@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Int32Value";
+    BEGIN
+      DotNetLevel.LevelIndex := DotNetInt32Value.FromInt32(NewLevelIndex);
+    END;
+
+    [External]
+    PROCEDURE SetNumberingFormatType@17024410(NewNumberingFormatType@17024401 : Integer);
+    VAR
+      DotNetNumberFormat@17024404 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.NumberingFormat";
+      DotNetNumberFormatValues@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.NumberFormatValues";
+      DotNetEnumValue@17024403 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.EnumValue`1";
+      OpenXmlDotNetHelper@17024402 : Codeunit 50067;
+    BEGIN
+      //We need this to deal with .NET Generics:
+      OpenXmlDotNetHelper.CreateEnumValueGeneric(GETDOTNETTYPE(DotNetNumberFormatValues), NewNumberingFormatType, DotNetEnumValue);
+      DotNetNumberFormat := DotNetNumberFormat.NumberingFormat;
+      DotNetNumberFormat.Val := DotNetEnumValue;
+      DotNetLevel.NumberingFormat := DotNetNumberFormat;
+    END;
+
+    [External]
+    PROCEDURE GetNumberingFormatType@17024408() : Integer;
+    VAR
+      DotNetNumberFormatValues@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.NumberFormatValues";
+      DotNetEnumValue@17024401 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.EnumValue`1";
+    BEGIN
+      DotNetEnumValue := DotNetLevel.NumberingFormat.Val;
+      DotNetNumberFormatValues := DotNetEnumValue.Value;
+      EXIT(DotNetNumberFormatValues);
+    END;
+
+    PROCEDURE SetLevel@17024411(NewDotNetLevel@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Level");
+    BEGIN
+      DotNetLevel := NewDotNetLevel;
+    END;
+
+    PROCEDURE GetLevel@17024400(VAR CurrentDotNetLevel@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.Level");
+    BEGIN
+      CurrentDotNetLevel := DotNetLevel;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50074.TXT
+++ b/BaseApp/COD50074.TXT
@@ -1,0 +1,77 @@
+OBJECT Codeunit 50074 DotNet_Word.NumberingInstance
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetNumberingInstance@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.NumberingInstance";
+
+    [External]
+    PROCEDURE Create@17024403();
+    BEGIN
+      DotNetNumberingInstance := DotNetNumberingInstance.NumberingInstance;
+    END;
+
+    [External]
+    PROCEDURE CreateFromOuterXml@17024408(OuterXml@17024400 : Text);
+    BEGIN
+      DotNetNumberingInstance := DotNetNumberingInstance.NumberingInstance(OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetOuterXml@17024401() : Text;
+    BEGIN
+      EXIT(DotNetNumberingInstance.OuterXml);
+    END;
+
+    [External]
+    PROCEDURE GetInnerText@17024410() : Text;
+    BEGIN
+      EXIT(DotNetNumberingInstance.InnerText);
+    END;
+
+    [External]
+    PROCEDURE SetNumberID@17024406(NewNumberID@17024401 : Integer);
+    VAR
+      DotNetInt32Value@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Int32Value";
+    BEGIN
+      DotNetNumberingInstance.NumberID := DotNetInt32Value.FromInt32(NewNumberID);
+    END;
+
+    [External]
+    PROCEDURE SetAbstractNumId@17024402(NewAbstractNumId@17024401 : Integer);
+    VAR
+      DotNetInt32Value@17024402 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Int32Value";
+      DotNetAbstractNumId@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.AbstractNumId";
+    BEGIN
+      DotNetAbstractNumId := DotNetAbstractNumId.AbstractNumId;
+      DotNetAbstractNumId.Val := DotNetInt32Value.FromInt32(NewAbstractNumId);
+      DotNetNumberingInstance.AbstractNumId := DotNetAbstractNumId;
+    END;
+
+    PROCEDURE SetNumberingInstance@17024411(NewDotNetNumberingInstance@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.NumberingInstance");
+    BEGIN
+      DotNetNumberingInstance := NewDotNetNumberingInstance;
+    END;
+
+    PROCEDURE GetNumberingInstance@17024400(VAR CurrentDotNetNumberingInstance@17024400 : DotNet "'DocumentFormat.OpenXml, Version=2.0.5022.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.DocumentFormat.OpenXml.Wordprocessing.NumberingInstance");
+    BEGIN
+      CurrentDotNetNumberingInstance := DotNetNumberingInstance;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50075.TXT
+++ b/BaseApp/COD50075.TXT
@@ -1,0 +1,52 @@
+OBJECT Codeunit 50075 DotNet_Word.AbstractNumEnumera
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+
+    PROCEDURE SetEnumerator@17024415(NewEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      DotNetEnumerator := NewEnumerator;
+    END;
+
+    PROCEDURE GetEnumerator@17024414(VAR CurrentEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      CurrentEnumerator := DotNetEnumerator;
+    END;
+
+    [External]
+    PROCEDURE Reset@17024401();
+    BEGIN
+      DotNetEnumerator.Reset;
+    END;
+
+    [External]
+    PROCEDURE MoveNext@17024402() : Boolean;
+    BEGIN
+      EXIT(DotNetEnumerator.MoveNext);
+    END;
+
+    [External]
+    PROCEDURE GetCurrent@17024403(VAR CurrentAbstractNum@17024400 : Codeunit 50072);
+    BEGIN
+      CurrentAbstractNum.SetAbstractNum(DotNetEnumerator.Current);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD50076.TXT
+++ b/BaseApp/COD50076.TXT
@@ -1,0 +1,52 @@
+OBJECT Codeunit 50076 DotNet_Word.TextEnumerator
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator";
+
+    PROCEDURE SetEnumerator@17024415(NewEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      DotNetEnumerator := NewEnumerator;
+    END;
+
+    PROCEDURE GetEnumerator@17024414(VAR CurrentEnumerator@17024400 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.IEnumerator");
+    BEGIN
+      CurrentEnumerator := DotNetEnumerator;
+    END;
+
+    [External]
+    PROCEDURE Reset@17024401();
+    BEGIN
+      DotNetEnumerator.Reset;
+    END;
+
+    [External]
+    PROCEDURE MoveNext@17024402() : Boolean;
+    BEGIN
+      EXIT(DotNetEnumerator.MoveNext);
+    END;
+
+    [External]
+    PROCEDURE GetCurrent@17024403(VAR CurrentText@17024400 : Codeunit 50024);
+    BEGIN
+      CurrentText.SetTextObject(DotNetEnumerator.Current);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/Test/COD50069.TXT
+++ b/Test/COD50069.TXT
@@ -1,0 +1,1010 @@
+OBJECT Codeunit 50069 Text_OpenXml.WordProcessing
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    Subtype=Test;
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      Assert@17024401 : Codeunit 130000;
+      LibraryLowerPermissions@17024400 : Codeunit 132217;
+      OpenXmlWordProcessingHelper@17024402 : Codeunit 50068;
+      WordprocessingDocument@17024405 : Codeunit 50018;
+      MainDocumentPart@17024404 : Codeunit 50019;
+      WordDocument@17024406 : Codeunit 50020;
+      WordBody@17024403 : Codeunit 50021;
+      WordParagraph@17024410 : Codeunit 50022;
+      WordRun@17024409 : Codeunit 50023;
+      WordText@17024408 : Codeunit 50024;
+      WordRunProperties@17024407 : Codeunit 50025;
+      WordColor@17024420 : Codeunit 50036;
+      WordParagraphProperties@17024419 : Codeunit 50026;
+      WordStyleRunProperties@17024418 : Codeunit 50037;
+      WordSpacingBetweenLines@17024417 : Codeunit 50030;
+      WordTable@17024416 : Codeunit 50027;
+      WordTableRow@17024415 : Codeunit 50028;
+      WordTableCell@17024414 : Codeunit 50029;
+      WordHyperlink@17024413 : Codeunit 50035;
+      WordStyleDefinitionPart@17024421 : Codeunit 50041;
+      WordStyles@17024422 : Codeunit 50039;
+      WordDrawing@17024423 : Codeunit 50043;
+      WordParagraphEnumerator@17024426 : Codeunit 50062;
+      WordRunEnumerator@17024425 : Codeunit 50063;
+      WordTextEnumerator@17024424 : Codeunit 50076;
+      TestFile@17024411 : File;
+      FileOutStream@17024412 : OutStream;
+
+    [Test]
+    PROCEDURE TestCreateSimpleDocument@17024400();
+    VAR
+      Expected@17024403 : Text;
+      Actual@17024400 : Text;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[WHEN] Empty Word document is created
+      CreateSampleDocument;
+      Actual := FinalizeAndGetDocumentOuterXml;
+      //[THEN] Expected document outer XML is:
+      Expected :=
+          '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body /></w:d'
+        + 'ocument>';
+      Assert.AreEqual(Expected, Actual, 'Simple document creation failed');
+    END;
+
+    [Test]
+    PROCEDURE TestCreateParagraph@17024419();
+    VAR
+      Expected@17024403 : Text;
+      Actual@17024400 : Text;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[WHEN] One paragraph is added to an empty document
+      CreateSampleDocument;
+      CreateSampleParagraph;
+      Actual := FinalizeAndGetDocumentOuterXml;
+      //[THEN] Expected document outer XML is:
+      Expected :=
+          '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:'
+        + 'r><w:t>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent quam augue, tempus id metu'
+        + 's in, laoreet viverra quam. Sed vulputate risus lacus, et dapibus orci porttitor non.</w:t></w:r></'
+        + 'w:p></w:body></w:document>';
+      Assert.AreEqual(Expected, Actual, 'Paragraph creation failed');
+    END;
+
+    [Test]
+    PROCEDURE TestCreateParagraphWithStyles@17024432();
+    VAR
+      Expected@17024403 : Text;
+      Actual@17024400 : Text;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[WHEN] One paragraph with formating styles is added to an empty document
+      CreateSampleDocument;
+      CreateSampleParagraphWithFormating;
+      Actual := FinalizeAndGetDocumentOuterXml;
+      //[THEN] Expected document outer XML is:
+      Expected :=
+          '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:'
+        + 'r><w:t xml:space="preserve">Pellentesque </w:t></w:r><w:r><w:rPr><w:b /></w:rPr><w:t xml:space="pre'
+        + 'serve">commodo </w:t></w:r><w:r><w:t xml:space="preserve">rhoncus </w:t></w:r><w:r><w:rPr><w:i /></'
+        + 'w:rPr><w:t xml:space="preserve">mauris</w:t></w:r><w:r><w:t xml:space="preserve">, sit </w:t></w:r>'
+        + '<w:r><w:rPr><w:b /><w:i /><w:u /></w:rPr><w:t xml:space="preserve">amet </w:t></w:r><w:r><w:t xml:s'
+        + 'pace="preserve">faucibus arcu </w:t></w:r><w:r><w:rPr><w:color w:val="FF0000" /></w:rPr><w:t xml:sp'
+        + 'ace="preserve">porttitor </w:t></w:r><w:r><w:t xml:space="preserve">pharetra. Maecenas quis erat qu'
+        + 'is eros iaculis placerat ut at mauris.</w:t></w:r></w:p></w:body></w:document>';
+      Assert.AreEqual(Expected, Actual, 'Paragraph with styles creation failed');
+    END;
+
+    [Test]
+    PROCEDURE TestCreateParagraphJustification@17024436();
+    VAR
+      Expected@17024403 : Text;
+      Actual@17024400 : Text;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[WHEN] One paragraph with justified text is added to an empty document
+      CreateSampleDocument;
+      CreateSampleParagraphJustified;
+      Actual := FinalizeAndGetDocumentOuterXml;
+      //[THEN] Expected document outer XML is:
+      Expected :=
+          '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:'
+        + 'pPr><w:jc w:val="center" /></w:pPr><w:r><w:t xml:space="preserve">Nam eu tortor ut mi euismod eleif'
+        + 'end in ut ante. Donec a ligula ante. Sed rutrum ex quam. Nunc id mi ultricies, vestibulum sapien ve'
+        + 'l, posuere dui.</w:t></w:r></w:p></w:body></w:document>';
+      Assert.AreEqual(Expected, Actual, 'Paragraph with justification creation failed');
+    END;
+
+    [Test]
+    PROCEDURE TestCreateHeadings@17024439();
+    VAR
+      Expected@17024403 : Text;
+      Actual@17024401 : Text;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[WHEN] Heading1 and Heading2 styles are added to an empty document
+      CreateSampleDocument;
+      CreateSampleHeadings;
+      Actual := FinalizeAndGetDocumentOuterXml;
+      //[THEN] Expected document outer XML is:
+      Expected :=
+          '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:'
+        + 'pPr><w:pStyle w:val="heading1" /><w:spacing w:after="0" /></w:pPr><w:r><w:t xml:space="preserve">Fi'
+        + 'rst Heading</w:t></w:r></w:p><w:p><w:pPr><w:pStyle w:val="heading2" /><w:spacing w:after="0" /></w:'
+        + 'pPr><w:r><w:t xml:space="preserve">Second Heading</w:t></w:r></w:p></w:body></w:document>';
+      Assert.AreEqual(Expected, Actual, 'Headings creation failed');
+      //[THEN] Styles definition part must be not empty
+      Assert.AreEqual(TRUE, MainDocumentPart.HasStyleDefinitionsPart, 'Style definitions check failed');
+      MainDocumentPart.GetStyleDefinitionsPart(WordStyleDefinitionPart);
+      WordStyleDefinitionPart.GetStyles(WordStyles);
+      Actual := WordStyles.GetOuterXml;
+      //[THEN] and expected styles outer xml is:
+      Expected :=
+          '<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:style w:type="p'
+        + 'aragraph" w:styleId="heading1" w:customStyle="true"><w:name w:val="heading 1" /><w:basedOn w:val="N'
+        + 'ormal" /><w:next w:val="Normal" /><w:uiPriority w:val="900" /><w:rPr xmlns:w="http://schemas.openxm'
+        + 'lformats.org/wordprocessingml/2006/main"><w:color w:val="2F5496" /><w:sz w:val="32" /></w:rPr></w:s'
+        + 'tyle><w:style w:type="paragraph" w:styleId="heading2" w:customStyle="true"><w:name w:val="heading 2'
+        + '" /><w:basedOn w:val="Normal" /><w:next w:val="Normal" /><w:uiPriority w:val="900" /><w:rPr xmlns:w'
+        + '="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:color w:val="2F5496" /><w:sz w:v'
+        + 'al="26" /></w:rPr></w:style></w:styles>';
+      Assert.AreEqual(Expected, Actual, 'Styles check failed');
+    END;
+
+    [Test]
+    PROCEDURE TestCreateTable@17024446();
+    VAR
+      Expected@17024403 : Text;
+      Actual@17024400 : Text;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[WHEN] Table is added to an empty document
+      CreateSampleDocument;
+      CreateSampleTable;
+      Actual := FinalizeAndGetDocumentOuterXml;
+      //[THEN] Expected document outer XML is:
+      Expected :=
+          '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><'
+        + 'w:tr><w:tc><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:rPr><w:b /></w:rPr><w:t>Nice'
+        + '</w:t></w:r></w:p></w:tc></w:tr><w:tr><w:tc><w:p><w:r><w:t>Little</w:t></w:r></w:p></w:tc><w:tc><w:'
+        + 'p><w:pPr><w:jc w:val="center" /></w:pPr><w:r><w:t>Table</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:'
+        + 'body></w:document>';
+      Assert.AreEqual(Expected, Actual, 'Table creation failed');
+    END;
+
+    [Test]
+    PROCEDURE TestCreateLists@17024453();
+    VAR
+      Expected@17024403 : Text;
+      Actual@17024400 : Text;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[WHEN] Sample lists are added to an empty document
+      CreateSampleDocument;
+      CreateSampleLists;
+      Actual := FinalizeAndGetDocumentOuterXml;
+      //[THEN] Expected document outer XML is:
+      Expected :=
+          '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:'
+        + 'pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:pStyle w:val="ListPar'
+        + 'agraph" /><w:numPr><w:ilvl w:val="0" /><w:numId w:val="1" /></w:numPr><w:spacing w:after="0" /><w:i'
+        + 'nd w:start="5" w:hanging="360" /></w:pPr><w:r><w:t>A</w:t></w:r></w:p><w:p><w:pPr xmlns:w="http://s'
+        + 'chemas.openxmlformats.org/wordprocessingml/2006/main"><w:pStyle w:val="ListParagraph" /><w:numPr><w'
+        + ':ilvl w:val="0" /><w:numId w:val="1" /></w:numPr><w:spacing w:after="0" /><w:ind w:start="5" w:hang'
+        + 'ing="360" /></w:pPr><w:r><w:t>Unordered</w:t></w:r></w:p><w:p><w:pPr xmlns:w="http://schemas.openxm'
+        + 'lformats.org/wordprocessingml/2006/main"><w:pStyle w:val="ListParagraph" /><w:numPr><w:ilvl w:val="'
+        + '0" /><w:numId w:val="1" /></w:numPr><w:spacing w:after="0" /><w:ind w:start="5" w:hanging="360" /><'
+        + '/w:pPr><w:r><w:t>List</w:t></w:r></w:p><w:p /><w:p><w:pPr xmlns:w="http://schemas.openxmlformats.or'
+        + 'g/wordprocessingml/2006/main"><w:pStyle w:val="ListParagraph" /><w:numPr><w:ilvl w:val="0" /><w:num'
+        + 'Id w:val="2" /></w:numPr><w:spacing w:after="0" /><w:ind w:start="10" w:hanging="360" /></w:pPr><w:'
+        + 'r><w:t>A</w:t></w:r></w:p><w:p><w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2'
+        + '006/main"><w:pStyle w:val="ListParagraph" /><w:numPr><w:ilvl w:val="0" /><w:numId w:val="2" /></w:n'
+        + 'umPr><w:spacing w:after="0" /><w:ind w:start="10" w:hanging="360" /></w:pPr><w:r><w:t>Ordered</w:t>'
+        + '</w:r></w:p><w:p><w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:p'
+        + 'Style w:val="ListParagraph" /><w:numPr><w:ilvl w:val="0" /><w:numId w:val="2" /></w:numPr><w:spacin'
+        + 'g w:after="0" /><w:ind w:start="10" w:hanging="360" /></w:pPr><w:r><w:t>List</w:t></w:r></w:p></w:b'
+        + 'ody></w:document>';
+      Assert.AreEqual(Expected, Actual, 'Lists creation failed');
+    END;
+
+    [Test]
+    PROCEDURE TestCreatePicture@17024456();
+    VAR
+      Expected@17024403 : Text;
+      PartId@17024405 : Text;
+      Actual@17024400 : Text;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[WHEN] Picture is added to an empty document
+      CreateSampleDocument;
+      PartId := CreateSamplePicture;
+      Actual := FinalizeAndGetDocumentOuterXml;
+      //[THEN] Expected document outer XML is:
+      Expected :=
+          '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:'
+        + 'r><w:drawing><wp:anchor distT="0" distB="0" distL="114300" distR="114300" simplePos="0" relativeHei'
+        + 'ght="251658240" behindDoc="1" locked="0" layoutInCell="1" allowOverlap="1" xmlns:wp="http://schemas'
+        + '.openxmlformats.org/drawingml/2006/wordprocessingDrawing"><wp:simplePos x="0" y="0" /><wp:positionH'
+        + ' relativeFrom="margin"><wp:align>left</wp:align></wp:positionH><wp:positionV relativeFrom="paragrap'
+        + 'h"><wp:posOffset>0</wp:posOffset></wp:positionV><wp:extent cx="209550" cy="209550" /><wp:effectExte'
+        + 'nt l="0" t="0" r="0" b="0" /><wp:wrapTopAndBottom /><wp:docPr id="1" name="someimage.Jpeg" /><wp:cN'
+        + 'vGraphicFramePr><a:graphicFrameLocks noChangeAspect="1" xmlns:a="http://schemas.openxmlformats.org/'
+        + 'drawingml/2006/main" /></wp:cNvGraphicFramePr><a:graphic xmlns:a="http://schemas.openxmlformats.org'
+        + '/drawingml/2006/main"><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture"'
+        + '><pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:nvPicPr><pic:cN'
+        + 'vPr id="0" name="someimage.Jpeg" /><pic:cNvPicPr /></pic:nvPicPr><pic:blipFill><a:blip r:embed="'
+        + PartId + '"'
+        + ' cstate="print" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><a:ex'
+        + 'tLst><a:ext uri="{28A0092B-C50C-407E-A947-70E740481C1C}" /></a:extLst></a:blip><a:stretch><a:fillRe'
+        + 'ct /></a:stretch></pic:blipFill><pic:spPr><a:xfrm><a:off x="0" y="0" /><a:ext cx="209550" cy="20955'
+        + '0" /></a:xfrm><a:prstGeom prst="rect"><a:avLst /></a:prstGeom></pic:spPr></pic:pic></a:graphicData>'
+        + '</a:graphic></wp:anchor></w:drawing></w:r></w:p></w:body></w:document>';
+      Assert.AreEqual(Expected, Actual, 'Paragraph creation failed');
+    END;
+
+    [Test]
+    PROCEDURE TestCreateHyperlink@17024402();
+    VAR
+      Expected@17024403 : Text;
+      PartId@17024400 : Text;
+      Actual@17024402 : Text;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[WHEN] Hyperlink is added to an empty document
+      CreateSampleDocument;
+      PartId := CreateSampleHyperlink;
+      Actual := FinalizeAndGetDocumentOuterXml;
+      //[THEN] Expected document outer XML is:
+      Expected :=
+          '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:'
+        + 'hyperlink w:history="true" r:id="'
+        + PartId + '" xmlns:r="http://schemas.openxmlformats.org/offi'
+        + 'ceDocument/2006/relationships"><w:proofErr w:type="gramStart" /><w:r><w:rPr><w:rStyle w:val="Hyperl'
+        + 'ink" /><w:color w:themeColor="hyperlink" /></w:rPr><w:t xml:space="preserve">My awesome link</w:t><'
+        + '/w:r></w:hyperlink></w:p></w:body></w:document>';
+      Assert.AreEqual(Expected, Actual, 'Paragraph creation failed');
+    END;
+
+    [Test]
+    PROCEDURE TestCreateFullDocumentNonEmpty@17024415();
+    VAR
+      Expected@17024403 : Text;
+      PictureBase64@17024404 : Text;
+      TempBlob@17024402 : TEMPORARY Record 99008535;
+      ImageStream@17024401 : InStream;
+      ExistingFileStream@17024400 : InStream;
+      SaveStream@17024405 : OutStream;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[WHEN] All elements from previous tests are added to an empty document
+      CreateSampleDocument;
+      CreateSampleParagraph;
+      CreateSampleParagraphWithFormating;
+      CreateSampleParagraphJustified;
+      CreateSampleHeadings;
+      CreateSampleTable;
+      CreateSampleLists;
+      CreateSamplePicture;
+      CreateSampleHyperlink;
+      FinalizeAndGetDocumentOuterXml;
+      //[WHEN] document is saved to TempBlob stream
+      TempBlob.Blob.CREATEOUTSTREAM(SaveStream);
+      WordprocessingDocument.Save(SaveStream);
+      //[WHEN] and then reopened again
+      TempBlob.Blob.CREATEINSTREAM(ExistingFileStream);
+      WordprocessingDocument.Open(ExistingFileStream, FALSE);
+      WordprocessingDocument.GetMainDocumentPart(MainDocumentPart);
+      MainDocumentPart.GetDocument(WordDocument);
+      //[THEN] document outer XML must not be empty
+      Assert.AreNotEqual('', WordDocument.GetOuterXml, 'Reopen check failed');
+    END;
+
+    [Test]
+    PROCEDURE TestFullDocumentIsSameOnReopen@17024404();
+    VAR
+      Expected@17024403 : Text;
+      ExistingFileStream@17024400 : InStream;
+      SaveStream@17024405 : OutStream;
+      TempBlob@17024401 : TEMPORARY Record 99008535;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[WHEN] All elements from previous tests are added to an empty document
+      CreateSampleDocument;
+      CreateSampleParagraph;
+      CreateSampleParagraphWithFormating;
+      CreateSampleParagraphJustified;
+      CreateSampleHeadings;
+      CreateSampleTable;
+      CreateSampleLists;
+      Expected := FinalizeAndGetDocumentOuterXml;
+      //[WHEN] document is saved to TempBlob stream and reopened
+      TempBlob.Blob.CREATEOUTSTREAM(SaveStream);
+      WordprocessingDocument.Save(SaveStream);
+      TempBlob.Blob.CREATEINSTREAM(ExistingFileStream);
+      WordprocessingDocument.Open(ExistingFileStream, FALSE);
+      WordprocessingDocument.GetMainDocumentPart(MainDocumentPart);
+      MainDocumentPart.GetDocument(WordDocument);
+      //[THEN] reopened stream document outer XML must be the same as original
+      Assert.AreEqual(Expected, WordDocument.GetOuterXml, 'Reopen check failed');
+    END;
+
+    [Test]
+    PROCEDURE TestExistingDocumentOpen@17024460();
+    VAR
+      DocumentBase64@17024402 : Text;
+      Expected@17024403 : Text;
+      ExistingFileStream@17024400 : InStream;
+      SaveStream@17024405 : OutStream;
+      TempBlob@17024401 : TEMPORARY Record 99008535;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[GIVEN] Sample document stream as base64 text
+      DocumentBase64 := GetExampleDocxFileContentAsBase64;
+      //[WHEN] Sample document is opened
+      TempBlob.FromBase64String(DocumentBase64);
+      TempBlob.Blob.CREATEINSTREAM(ExistingFileStream);
+      WordprocessingDocument.Open(ExistingFileStream, FALSE);
+      WordprocessingDocument.GetMainDocumentPart(MainDocumentPart);
+      MainDocumentPart.GetDocument(WordDocument);
+      //[THEN] Expected document outer XML is:
+      Expected :=
+          '<w:document xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns'
+        + ':a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:pic="http://schemas.openxmlformats'
+        + '.org/drawingml/2006/picture" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relatio'
+        + 'nships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w'
+        + ':t>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent quam augue, tempus id metus in'
+        + ', laoreet viverra quam. Sed vulputate risus lacus, et dapibus orci porttitor non.</w:t></w:r></w:p>'
+        + '<w:p><w:r><w:t xml:space="preserve">Pellentesque </w:t></w:r><w:r><w:rPr><w:b /></w:rPr><w:t xml:sp'
+        + 'ace="preserve">commodo </w:t></w:r><w:r><w:t xml:space="preserve">rhoncus </w:t></w:r><w:r><w:rPr><'
+        + 'w:i /></w:rPr><w:t xml:space="preserve">mauris</w:t></w:r><w:r><w:t xml:space="preserve">, sit </w:'
+        + 't></w:r><w:r><w:rPr><w:b /><w:i /><w:u /></w:rPr><w:t xml:space="preserve">amet </w:t></w:r><w:r><w'
+        + ':t xml:space="preserve">faucibus arcu </w:t></w:r><w:r><w:rPr><w:color w:val="FF0000" /></w:rPr><w:'
+        + 't xml:space="preserve">porttitor </w:t></w:r><w:r><w:t xml:space="preserve">pharetra. Maecenas quis'
+        + ' erat quis eros iaculis placerat ut at mauris.</w:t></w:r></w:p><w:p><w:pPr><w:jc w:val="center" />'
+        + '</w:pPr><w:r><w:t xml:space="preserve">Nam eu tortor ut mi euismod eleifend in ut ante. Donec a lig'
+        + 'ula ante. Sed rutrum ex quam. Nunc id mi ultricies, vestibulum sapien vel, posuere dui.</w:t></w:r>'
+        + '</w:p><w:p><w:pPr><w:pStyle w:val="heading1" /><w:spacing w:after="0" /></w:pPr><w:r><w:t xml:space'
+        + '="preserve">First Heading</w:t></w:r></w:p><w:p><w:pPr><w:pStyle w:val="heading2" /><w:spacing w:af'
+        + 'ter="0" /></w:pPr><w:r><w:t xml:space="preserve">Second Heading</w:t></w:r></w:p><w:tbl><w:tr><w:tc'
+        + '><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:rPr><w:b /></w:rPr><w:t>Nice</w:t></w:'
+        + 'r></w:p></w:tc></w:tr><w:tr><w:tc><w:p><w:r><w:t>Little</w:t></w:r></w:p></w:tc><w:tc><w:p><w:pPr><'
+        + 'w:jc w:val="center" /></w:pPr><w:r><w:t>Table</w:t></w:r></w:p></w:tc></w:tr></w:tbl><w:p><w:pPr xm'
+        + 'lns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:pStyle w:val="ListParagraph'
+        + '" /><w:numPr><w:ilvl w:val="0" /><w:numId w:val="1" /></w:numPr><w:spacing w:after="0" /><w:ind w:s'
+        + 'tart="5" w:hanging="360" /></w:pPr><w:r><w:t>A</w:t></w:r></w:p><w:p><w:pPr xmlns:w="http://schemas'
+        + '.openxmlformats.org/wordprocessingml/2006/main"><w:pStyle w:val="ListParagraph" /><w:numPr><w:ilvl '
+        + 'w:val="0" /><w:numId w:val="1" /></w:numPr><w:spacing w:after="0" /><w:ind w:start="5" w:hanging="3'
+        + '60" /></w:pPr><w:r><w:t>Unordered</w:t></w:r></w:p><w:p><w:pPr xmlns:w="http://schemas.openxmlforma'
+        + 'ts.org/wordprocessingml/2006/main"><w:pStyle w:val="ListParagraph" /><w:numPr><w:ilvl w:val="0" /><'
+        + 'w:numId w:val="1" /></w:numPr><w:spacing w:after="0" /><w:ind w:start="5" w:hanging="360" /></w:pPr'
+        + '><w:r><w:t>List</w:t></w:r></w:p><w:p /><w:p><w:pPr xmlns:w="http://schemas.openxmlformats.org/word'
+        + 'processingml/2006/main"><w:pStyle w:val="ListParagraph" /><w:numPr><w:ilvl w:val="0" /><w:numId w:v'
+        + 'al="2" /></w:numPr><w:spacing w:after="0" /><w:ind w:start="10" w:hanging="360" /></w:pPr><w:r><w:t'
+        + '>A</w:t></w:r></w:p><w:p><w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/ma'
+        + 'in"><w:pStyle w:val="ListParagraph" /><w:numPr><w:ilvl w:val="0" /><w:numId w:val="2" /></w:numPr><'
+        + 'w:spacing w:after="0" /><w:ind w:start="10" w:hanging="360" /></w:pPr><w:r><w:t>Ordered</w:t></w:r>'
+        + '</w:p><w:p><w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:pStyle '
+        + 'w:val="ListParagraph" /><w:numPr><w:ilvl w:val="0" /><w:numId w:val="2" /></w:numPr><w:spacing w:af'
+        + 'ter="0" /><w:ind w:start="10" w:hanging="360" /></w:pPr><w:r><w:t>List</w:t></w:r></w:p><w:p><w:r><'
+        + 'w:drawing><wp:anchor xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawi'
+        + 'ng" distT="0" distB="0" distL="114300" distR="114300" simplePos="0" relativeHeight="251658240" behi'
+        + 'ndDoc="1" locked="0" layoutInCell="1" allowOverlap="1"><wp:simplePos x="0" y="0" /><wp:positionH re'
+        + 'lativeFrom="margin"><wp:align>left</wp:align></wp:positionH><wp:positionV relativeFrom="paragraph">'
+        + '<wp:posOffset>0</wp:posOffset></wp:positionV><wp:extent cx="209550" cy="209550" /><wp:effectExtent '
+        + 'l="0" t="0" r="0" b="0" /><wp:wrapTopAndBottom /><wp:docPr id="1" name="someimage.Jpeg" /><wp:cNvGr'
+        + 'aphicFramePr><a:graphicFrameLocks xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" n'
+        + 'oChangeAspect="1" /></wp:cNvGraphicFramePr><a:graphic xmlns:a="http://schemas.openxmlformats.org/dr'
+        + 'awingml/2006/main"><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture"><p'
+        + 'ic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"><pic:nvPicPr><pic:cNvPr'
+        + ' id="0" name="someimage.Jpeg" /><pic:cNvPicPr /></pic:nvPicPr><pic:blipFill><a:blip xmlns:r="http:/'
+        + '/schemas.openxmlformats.org/officeDocument/2006/relationships" r:embed="R8348b073f4c5403c" cstate="'
+        + 'print"><a:extLst><a:ext uri="{28A0092B-C50C-407E-A947-70E740481C1C}" /></a:extLst></a:blip><a:stret'
+        + 'ch><a:fillRect /></a:stretch></pic:blipFill><pic:spPr><a:xfrm><a:off x="0" y="0" /><a:ext cx="20955'
+        + '0" cy="209550" /></a:xfrm><a:prstGeom prst="rect"><a:avLst /></a:prstGeom></pic:spPr></pic:pic></a:'
+        + 'graphicData></a:graphic></wp:anchor></w:drawing></w:r></w:p><w:p><w:hyperlink xmlns:r="http://schem'
+        + 'as.openxmlformats.org/officeDocument/2006/relationships" w:history="true" r:id="Ra2bda11c9d7f4e65">'
+        + '<w:proofErr w:type="gramStart" /><w:r><w:rPr><w:rStyle w:val="Hyperlink" /><w:color w:themeColor="h'
+        + 'yperlink" /></w:rPr><w:t xml:space="preserve">My awesome link</w:t></w:r></w:hyperlink></w:p></w:bo'
+        + 'dy></w:document>';
+      Assert.AreEqual(Expected, WordDocument.GetOuterXml, 'Existing file open check failed');
+    END;
+
+    [Test]
+    PROCEDURE TestExistingDocumentInspection@17024468();
+    VAR
+      DocumentBase64@17024402 : Text;
+      Expected@17024403 : Text;
+      ExistingFileStream@17024400 : InStream;
+      SaveStream@17024405 : OutStream;
+      TempBlob@17024401 : TEMPORARY Record 99008535;
+      ParagraphCount@17024404 : Integer;
+      RunCount@17024406 : Integer;
+      TextCount@17024407 : Integer;
+      FullText@17024408 : Text;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[GIVEN] Sample document stream as base64 text
+      DocumentBase64 := GetExampleDocxFileContentAsBase64;
+      //[WHEN] Sample document is opened
+      TempBlob.FromBase64String(DocumentBase64);
+      TempBlob.Blob.CREATEINSTREAM(ExistingFileStream);
+      WordprocessingDocument.Open(ExistingFileStream, FALSE);
+      WordprocessingDocument.GetMainDocumentPart(MainDocumentPart);
+      MainDocumentPart.GetDocument(WordDocument);
+      WordDocument.GetBody(WordBody);
+      //[WHEN] and iteration through all elements is performed
+      WordBody.GetParagraphEnumerator(WordParagraphEnumerator);
+      WHILE WordParagraphEnumerator.MoveNext DO
+        BEGIN
+          ParagraphCount += 1;
+          WordParagraphEnumerator.GetCurrent(WordParagraph);
+          WordParagraph.GetRunEnumerator(WordRunEnumerator);
+          WHILE WordRunEnumerator.MoveNext DO
+            BEGIN
+              RunCount += 1;
+              WordRunEnumerator.GetCurrent(WordRun);
+              WordRun.GetTextEnumerator(WordTextEnumerator);
+              WHILE WordTextEnumerator.MoveNext DO
+                BEGIN
+                  TextCount += 1;
+                  WordTextEnumerator.GetCurrent(WordText);
+                  FullText += WordText.GetInnerText;
+                END;
+            END;
+        END;
+
+      //[THEN] Expected paragraph element count is 14
+      Assert.AreEqual(14, ParagraphCount, 'Paragraph count check failed');
+      //[THEN] Expected run element count is 20
+      Assert.AreEqual(20, RunCount, 'Run count check failed');
+      //[THEN] Expected text element count is 19
+      Assert.AreEqual(19, TextCount, 'Text count check failed');
+      //[THEN] Expected concatenation of whole document text is:
+      Expected :=
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent quam augue, tempus id metus in, l'
+        + 'aoreet viverra quam. Sed vulputate risus lacus, et dapibus orci porttitor non.Pellentesque commodo '
+        + 'rhoncus mauris, sit amet faucibus arcu porttitor pharetra. Maecenas quis erat quis eros iaculis pla'
+        + 'cerat ut at mauris.Nam eu tortor ut mi euismod eleifend in ut ante. Donec a ligula ante. Sed rutrum'
+        + ' ex quam. Nunc id mi ultricies, vestibulum sapien vel, posuere dui.First HeadingSecond HeadingAUnor'
+        + 'deredListAOrderedList';
+      Assert.AreEqual(Expected, FullText, 'Full document text check failed');
+    END;
+
+    [Test]
+    PROCEDURE TestExistingDocumentModification@17024478();
+    VAR
+      DocumentBase64@17024402 : Text;
+      Expected@17024403 : Text;
+      ExistingFileStream@17024400 : InStream;
+      SaveStream@17024405 : OutStream;
+      TempBlob@17024401 : TEMPORARY Record 99008535;
+      Actual@17024408 : Text;
+    BEGIN
+      LibraryLowerPermissions.SetO365Basic;
+      //[GIVEN] Sample document stream as base64 text
+      DocumentBase64 := GetExampleDocxFileContentAsBase64;
+      //[WHEN] Sample document is opened
+      TempBlob.FromBase64String(DocumentBase64);
+      TempBlob.Blob.CREATEINSTREAM(ExistingFileStream);
+      WordprocessingDocument.Open(ExistingFileStream, TRUE);
+      WordprocessingDocument.GetMainDocumentPart(MainDocumentPart);
+      MainDocumentPart.GetDocument(WordDocument);
+      WordDocument.GetBody(WordBody);
+      //[WHEN] and '|>><<|' is added to every text element value
+      WordBody.GetParagraphEnumerator(WordParagraphEnumerator);
+      WHILE WordParagraphEnumerator.MoveNext DO
+        BEGIN
+          WordParagraphEnumerator.GetCurrent(WordParagraph);
+          WordParagraph.GetRunEnumerator(WordRunEnumerator);
+          WHILE WordRunEnumerator.MoveNext DO
+            BEGIN
+              WordRunEnumerator.GetCurrent(WordRun);
+              WordRun.GetTextEnumerator(WordTextEnumerator);
+              WHILE WordTextEnumerator.MoveNext DO
+                BEGIN
+                  WordTextEnumerator.GetCurrent(WordText);
+                  WordText.SetText(WordText.GetText + '|>><<|');
+                END;
+            END;
+        END;
+
+      Actual := FinalizeAndGetDocumentOuterXml;
+      //[THEN] Expected modified document outer xml is:
+      Expected :=
+          '<w:document xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns'
+        + ':a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:pic="http://schemas.openxmlformats'
+        + '.org/drawingml/2006/picture" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relatio'
+        + 'nships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w'
+        + ':t>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent quam augue, tempus id metus in'
+        + ', laoreet viverra quam. Sed vulputate risus lacus, et dapibus orci porttitor non.|&gt;&gt;&lt;&lt;|'
+        + '</w:t></w:r></w:p><w:p><w:r><w:t xml:space="preserve">Pellentesque |&gt;&gt;&lt;&lt;|</w:t></w:r><w'
+        + ':r><w:rPr><w:b /></w:rPr><w:t xml:space="preserve">commodo |&gt;&gt;&lt;&lt;|</w:t></w:r><w:r><w:t '
+        + 'xml:space="preserve">rhoncus |&gt;&gt;&lt;&lt;|</w:t></w:r><w:r><w:rPr><w:i /></w:rPr><w:t xml:spac'
+        + 'e="preserve">mauris|&gt;&gt;&lt;&lt;|</w:t></w:r><w:r><w:t xml:space="preserve">, sit |&gt;&gt;&lt;'
+        + '&lt;|</w:t></w:r><w:r><w:rPr><w:b /><w:i /><w:u /></w:rPr><w:t xml:space="preserve">amet |&gt;&gt;&'
+        + 'lt;&lt;|</w:t></w:r><w:r><w:t xml:space="preserve">faucibus arcu |&gt;&gt;&lt;&lt;|</w:t></w:r><w:r'
+        + '><w:rPr><w:color w:val="FF0000" /></w:rPr><w:t xml:space="preserve">porttitor |&gt;&gt;&lt;&lt;|</w'
+        + ':t></w:r><w:r><w:t xml:space="preserve">pharetra. Maecenas quis erat quis eros iaculis placerat ut '
+        + 'at mauris.|&gt;&gt;&lt;&lt;|</w:t></w:r></w:p><w:p><w:pPr><w:jc w:val="center" /></w:pPr><w:r><w:t '
+        + 'xml:space="preserve">Nam eu tortor ut mi euismod eleifend in ut ante. Donec a ligula ante. Sed rutr'
+        + 'um ex quam. Nunc id mi ultricies, vestibulum sapien vel, posuere dui.|&gt;&gt;&lt;&lt;|</w:t></w:r>'
+        + '</w:p><w:p><w:pPr><w:pStyle w:val="heading1" /><w:spacing w:after="0" /></w:pPr><w:r><w:t xml:space'
+        + '="preserve">First Heading|&gt;&gt;&lt;&lt;|</w:t></w:r></w:p><w:p><w:pPr><w:pStyle w:val="heading2"'
+        + ' /><w:spacing w:after="0" /></w:pPr><w:r><w:t xml:space="preserve">Second Heading|&gt;&gt;&lt;&lt;|'
+        + '</w:t></w:r></w:p><w:tbl><w:tr><w:tc><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:rP'
+        + 'r><w:b /></w:rPr><w:t>Nice</w:t></w:r></w:p></w:tc></w:tr><w:tr><w:tc><w:p><w:r><w:t>Little</w:t></'
+        + 'w:r></w:p></w:tc><w:tc><w:p><w:pPr><w:jc w:val="center" /></w:pPr><w:r><w:t>Table</w:t></w:r></w:p>'
+        + '</w:tc></w:tr></w:tbl><w:p><w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/'
+        + 'main"><w:pStyle w:val="ListParagraph" /><w:numPr><w:ilvl w:val="0" /><w:numId w:val="1" /></w:numPr'
+        + '><w:spacing w:after="0" /><w:ind w:start="5" w:hanging="360" /></w:pPr><w:r><w:t>A|&gt;&gt;&lt;&lt;'
+        + '|</w:t></w:r></w:p><w:p><w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/mai'
+        + 'n"><w:pStyle w:val="ListParagraph" /><w:numPr><w:ilvl w:val="0" /><w:numId w:val="1" /></w:numPr><w'
+        + ':spacing w:after="0" /><w:ind w:start="5" w:hanging="360" /></w:pPr><w:r><w:t>Unordered|&gt;&gt;&lt'
+        + ';&lt;|</w:t></w:r></w:p><w:p><w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/200'
+        + '6/main"><w:pStyle w:val="ListParagraph" /><w:numPr><w:ilvl w:val="0" /><w:numId w:val="1" /></w:num'
+        + 'Pr><w:spacing w:after="0" /><w:ind w:start="5" w:hanging="360" /></w:pPr><w:r><w:t>List|&gt;&gt;&lt'
+        + ';&lt;|</w:t></w:r></w:p><w:p /><w:p><w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessin'
+        + 'gml/2006/main"><w:pStyle w:val="ListParagraph" /><w:numPr><w:ilvl w:val="0" /><w:numId w:val="2" />'
+        + '</w:numPr><w:spacing w:after="0" /><w:ind w:start="10" w:hanging="360" /></w:pPr><w:r><w:t>A|&gt;&g'
+        + 't;&lt;&lt;|</w:t></w:r></w:p><w:p><w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingm'
+        + 'l/2006/main"><w:pStyle w:val="ListParagraph" /><w:numPr><w:ilvl w:val="0" /><w:numId w:val="2" /></'
+        + 'w:numPr><w:spacing w:after="0" /><w:ind w:start="10" w:hanging="360" /></w:pPr><w:r><w:t>Ordered|&g'
+        + 't;&gt;&lt;&lt;|</w:t></w:r></w:p><w:p><w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocess'
+        + 'ingml/2006/main"><w:pStyle w:val="ListParagraph" /><w:numPr><w:ilvl w:val="0" /><w:numId w:val="2" '
+        + '/></w:numPr><w:spacing w:after="0" /><w:ind w:start="10" w:hanging="360" /></w:pPr><w:r><w:t>List|&'
+        + 'gt;&gt;&lt;&lt;|</w:t></w:r></w:p><w:p><w:r><w:drawing><wp:anchor xmlns:wp="http://schemas.openxmlf'
+        + 'ormats.org/drawingml/2006/wordprocessingDrawing" distT="0" distB="0" distL="114300" distR="114300" '
+        + 'simplePos="0" relativeHeight="251658240" behindDoc="1" locked="0" layoutInCell="1" allowOverlap="1"'
+        + '><wp:simplePos x="0" y="0" /><wp:positionH relativeFrom="margin"><wp:align>left</wp:align></wp:posi'
+        + 'tionH><wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV><wp:exten'
+        + 't cx="209550" cy="209550" /><wp:effectExtent l="0" t="0" r="0" b="0" /><wp:wrapTopAndBottom /><wp:d'
+        + 'ocPr id="1" name="someimage.Jpeg" /><wp:cNvGraphicFramePr><a:graphicFrameLocks xmlns:a="http://sche'
+        + 'mas.openxmlformats.org/drawingml/2006/main" noChangeAspect="1" /></wp:cNvGraphicFramePr><a:graphic '
+        + 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:graphicData uri="http://schemas.'
+        + 'openxmlformats.org/drawingml/2006/picture"><pic:pic xmlns:pic="http://schemas.openxmlformats.org/dr'
+        + 'awingml/2006/picture"><pic:nvPicPr><pic:cNvPr id="0" name="someimage.Jpeg" /><pic:cNvPicPr /></pic:'
+        + 'nvPicPr><pic:blipFill><a:blip xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relati'
+        + 'onships" r:embed="R8348b073f4c5403c" cstate="print"><a:extLst><a:ext uri="{28A0092B-C50C-407E-A947-'
+        + '70E740481C1C}" /></a:extLst></a:blip><a:stretch><a:fillRect /></a:stretch></pic:blipFill><pic:spPr>'
+        + '<a:xfrm><a:off x="0" y="0" /><a:ext cx="209550" cy="209550" /></a:xfrm><a:prstGeom prst="rect"><a:a'
+        + 'vLst /></a:prstGeom></pic:spPr></pic:pic></a:graphicData></a:graphic></wp:anchor></w:drawing></w:r>'
+        + '</w:p><w:p><w:hyperlink xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationship'
+        + 's" w:history="true" r:id="Ra2bda11c9d7f4e65"><w:proofErr w:type="gramStart" /><w:r><w:rPr><w:rStyle'
+        + ' w:val="Hyperlink" /><w:color w:themeColor="hyperlink" /></w:rPr><w:t xml:space="preserve">My aweso'
+        + 'me link</w:t></w:r></w:hyperlink></w:p></w:body></w:document>';
+
+      Assert.AreEqual(Expected, Actual, 'Full document text check failed');
+    END;
+
+    LOCAL PROCEDURE CreateSampleDocument@17024447();
+    BEGIN
+      OpenXmlWordProcessingHelper.CreateEmptyDocument(0, WordprocessingDocument, MainDocumentPart, WordBody);
+      MainDocumentPart.GetDocument(WordDocument);
+    END;
+
+    LOCAL PROCEDURE CreateSampleParagraph@17024421();
+    BEGIN
+      WordText.Create;
+      WordText.SetText('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent quam augue, tempus id metus in, laoreet viverra quam. Sed vulputate risus lacus, et dapibus orci porttitor non.');
+      WordRun.Create;
+      WordRun.AppendText(WordText);
+      WordParagraph.Create;
+      WordParagraph.AppendRun(WordRun);
+      WordBody.AppendParagraph(WordParagraph);
+    END;
+
+    LOCAL PROCEDURE CreateSampleParagraphWithFormating@17024423();
+    BEGIN
+      WordParagraph.Create;
+
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetText('Pellentesque ');
+      WordText.SetSpacePreserveOption(TRUE);
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+
+      WordRun.Create;
+      WordRunProperties.Create;
+      WordRunProperties.SetBold(TRUE);
+      WordRun.AppendProperties(WordRunProperties);
+      WordText.Create;
+      WordText.SetText('commodo ');
+      WordText.SetSpacePreserveOption(TRUE);
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetText('rhoncus ');
+      WordText.SetSpacePreserveOption(TRUE);
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+
+      WordRun.Create;
+      WordRunProperties.Create;
+      WordRunProperties.SetItalic(TRUE);
+      WordRun.AppendProperties(WordRunProperties);
+      WordText.Create;
+      WordText.SetText('mauris');
+      WordText.SetSpacePreserveOption(TRUE);
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetText(', sit ');
+      WordText.SetSpacePreserveOption(TRUE);
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+
+      WordRun.Create;
+      WordRunProperties.Create;
+      WordRunProperties.SetBold(TRUE);
+      WordRunProperties.SetItalic(TRUE);
+      WordRunProperties.SetUnderline(TRUE);
+      WordRun.AppendProperties(WordRunProperties);
+      WordText.Create;
+      WordText.SetText('amet ');
+      WordText.SetSpacePreserveOption(TRUE);
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetText('faucibus arcu ');
+      WordText.SetSpacePreserveOption(TRUE);
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+
+      WordRun.Create;
+      WordRunProperties.Create;
+      WordColor.Create;
+      WordColor.SetColorValue('FF0000');
+      WordRunProperties.SetColor(WordColor);
+      WordRun.AppendProperties(WordRunProperties);
+      WordText.Create;
+      WordText.SetText('porttitor ');
+      WordText.SetSpacePreserveOption(TRUE);
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetText('pharetra. Maecenas quis erat quis eros iaculis placerat ut at mauris.');
+      WordText.SetSpacePreserveOption(TRUE);
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+
+      WordBody.AppendParagraph(WordParagraph);
+    END;
+
+    LOCAL PROCEDURE CreateSampleParagraphJustified@17024425();
+    BEGIN
+      WordParagraph.Create;
+      WordParagraphProperties.Create;
+      WordParagraphProperties.SetJustification(2); //Type = Center
+      WordParagraph.AppendProperties(WordParagraphProperties);
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetSpacePreserveOption(TRUE);
+      WordText.SetText('Nam eu tortor ut mi euismod eleifend in ut ante. Donec a ligula ante. Sed rutrum ex quam. Nunc id mi ultricies, vestibulum sapien vel, posuere dui.');
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+      WordBody.AppendParagraph(WordParagraph);
+    END;
+
+    LOCAL PROCEDURE CreateSampleHeadings@17024428();
+    BEGIN
+      WordStyleRunProperties.Create;
+      WordColor.Create;
+      WordColor.SetColorValue('2F5496');
+      WordStyleRunProperties.SetColor(WordColor);
+      WordStyleRunProperties.SetFontSize('32');
+      OpenXmlWordProcessingHelper.AddParagraphStyleToDocument(MainDocumentPart, 'heading1', 'heading 1', WordStyleRunProperties);
+
+      WordStyleRunProperties.Create;
+      WordColor.Create;
+      WordColor.SetColorValue('2F5496');
+      WordStyleRunProperties.SetColor(WordColor);
+      WordStyleRunProperties.SetFontSize('26');
+      OpenXmlWordProcessingHelper.AddParagraphStyleToDocument(MainDocumentPart, 'heading2', 'heading 2', WordStyleRunProperties);
+
+      WordParagraph.Create;
+      WordParagraphProperties.Create;
+      WordParagraphProperties.SetParagraphStyleId('heading1');
+      WordSpacingBetweenLines.Create;
+      WordSpacingBetweenLines.SetAfter('0');
+      WordParagraphProperties.SetSpacingBetweenLines(WordSpacingBetweenLines);
+      WordParagraph.AppendProperties(WordParagraphProperties);
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetSpacePreserveOption(TRUE);
+      WordText.SetText('First Heading');
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+      WordBody.AppendParagraph(WordParagraph);
+
+      WordParagraph.Create;
+      WordParagraphProperties.Create;
+      WordParagraphProperties.SetParagraphStyleId('heading2');
+      WordSpacingBetweenLines.Create;
+      WordSpacingBetweenLines.SetAfter('0');
+      WordParagraphProperties.SetSpacingBetweenLines(WordSpacingBetweenLines);
+      WordParagraph.AppendProperties(WordParagraphProperties);
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetSpacePreserveOption(TRUE);
+      WordText.SetText('Second Heading');
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+      WordBody.AppendParagraph(WordParagraph);
+    END;
+
+    LOCAL PROCEDURE CreateSampleTable@17024430();
+    BEGIN
+      WordTable.Create;
+      WordTableRow.Create;
+      WordTableCell.Create;
+      WordParagraph.Create;
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetText('A');
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+      WordTableCell.AppendParagraph(WordParagraph);
+      WordTableRow.AppendCell(WordTableCell);
+
+      WordTableCell.Create;
+      WordParagraph.Create;
+      WordRun.Create;
+      WordRunProperties.Create;
+      WordRunProperties.SetBold(TRUE);
+      WordRun.AppendProperties(WordRunProperties);
+      WordText.Create;
+      WordText.SetText('Nice');
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+      WordTableCell.AppendParagraph(WordParagraph);
+      WordTableRow.AppendCell(WordTableCell);
+
+      WordTable.AppendRow(WordTableRow);
+
+      WordTableRow.Create;
+      WordTableCell.Create;
+      WordParagraph.Create;
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetText('Little');
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+      WordTableCell.AppendParagraph(WordParagraph);
+      WordTableRow.AppendCell(WordTableCell);
+
+      WordTableCell.Create;
+      WordParagraph.Create;
+      WordParagraphProperties.Create;
+      WordParagraphProperties.SetJustification(2);
+      WordParagraph.AppendProperties(WordParagraphProperties);
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetText('Table');
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+      WordTableCell.AppendParagraph(WordParagraph);
+      WordTableRow.AppendCell(WordTableCell);
+
+      WordTable.AppendRow(WordTableRow);
+      WordBody.AppendTable(WordTable);
+    END;
+
+    LOCAL PROCEDURE CreateSampleLists@17024433();
+    BEGIN
+      OpenXmlWordProcessingHelper.CreateBulletListProperties(MainDocumentPart, WordParagraphProperties, '5');
+      WordParagraph.Create;
+      WordParagraphProperties.CreateFromOuterXml(WordParagraphProperties.GetOuterXml);
+      WordParagraph.AppendProperties(WordParagraphProperties);
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetText('A');
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+      WordBody.AppendParagraph(WordParagraph);
+      WordParagraph.Create;
+      WordParagraphProperties.CreateFromOuterXml(WordParagraphProperties.GetOuterXml);
+      WordParagraph.AppendProperties(WordParagraphProperties);
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetText('Unordered');
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+      WordBody.AppendParagraph(WordParagraph);
+      WordParagraph.Create;
+      WordParagraphProperties.CreateFromOuterXml(WordParagraphProperties.GetOuterXml);
+      WordParagraph.AppendProperties(WordParagraphProperties);
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetText('List');
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+      WordBody.AppendParagraph(WordParagraph);
+      WordParagraph.Create;
+      WordBody.AppendParagraph(WordParagraph);
+      OpenXmlWordProcessingHelper.CreateOrderedListProperties(MainDocumentPart, WordParagraphProperties, '10');
+      WordParagraph.Create;
+      WordParagraphProperties.CreateFromOuterXml(WordParagraphProperties.GetOuterXml);
+      WordParagraph.AppendProperties(WordParagraphProperties);
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetText('A');
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+      WordBody.AppendParagraph(WordParagraph);
+      WordParagraph.Create;
+      WordParagraphProperties.CreateFromOuterXml(WordParagraphProperties.GetOuterXml);
+      WordParagraph.AppendProperties(WordParagraphProperties);
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetText('Ordered');
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+      WordBody.AppendParagraph(WordParagraph);
+      WordParagraph.Create;
+      WordParagraphProperties.CreateFromOuterXml(WordParagraphProperties.GetOuterXml);
+      WordParagraph.AppendProperties(WordParagraphProperties);
+      WordRun.Create;
+      WordText.Create;
+      WordText.SetText('List');
+      WordRun.AppendText(WordText);
+      WordParagraph.AppendRun(WordRun);
+      WordBody.AppendParagraph(WordParagraph);
+    END;
+
+    LOCAL PROCEDURE CreateSamplePicture@17024435() : Text;
+    VAR
+      PictureBase64@17024402 : Text;
+      TempBlob@17024401 : TEMPORARY Record 99008535;
+      ImageStream@17024400 : InStream;
+      PartId@17024403 : Text;
+    BEGIN
+      PictureBase64 :=
+          '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMF'
+        + 'BwYHBwcGBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsMDAz/2wBDAQICAgMDAwYD'
+        + 'AwYMCAcIDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM'
+        + 'DAwMDAz/wAARCAAVABYDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQF'
+        + 'BgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEI'
+        + 'I0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNk'
+        + 'ZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLD'
+        + 'xMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEB'
+        + 'AQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJB'
+        + 'UQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZH'
+        + 'SElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaan'
+        + 'qKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oA'
+        + 'DAMBAAIRAxEAPwD6B/bw/wCClPxO/bC/actPhV8Bb3X9P07T9VksLK48O6j5V54nuk3o'
+        + '9x9phcKtkqh2T5xGUBmlb7qw8X45/wCCSn7SP7EPgnWPH/hrxVpcX9l2Mz6rN4R8R3Nj'
+        + 'e29hHG1xNI7SJb74l8lSURmctswhxkYPwS8ceIP+CK//AAUH1a38U6BdaxpJgm0ieUwi'
+        + 'CfVNHluEePULP94Y95NujbGdhlZYWZHBdPvb4/f8F1Pgn4J+F+p3XgjX7rxf4qkgli0y'
+        + 'zj0S7igiuDFIYpbgziAfZxIqBxG5kw/yqeSPzmjHDYpVa2ZVnGqm9L25fRdfl/wT+681'
+        + 'r59w7LL8q4CyyGIy6rCLdTkc1Wbd26s18G905aau2i5Yn/BGj/gofrH7ZHw+8QeHvHeq'
+        + 'Wt/4+8Lzi5E6wQWj6np8p+WQRxkBnik3I7JEiKsltnc7sSV88/8ABuf8ANTm8beOPinL'
+        + 'J5Oj29ifCtqm1G+2XEkkF1Mc79yeUscHVMP9p4bMbCivrOHq9atgITr766vdq+j/AK9T'
+        + '+bfG/KMqyzjLF4TKEo01ytxirRhJxTlFW0snrZaRvy6WsfoD+1N+wz8Mf2xtEaDxv4at'
+        + 'bvUUgMFprNt/o+qWICyhNk6/Myo0zuIpN8RcgtG2K+efBX/Bv18CfC3ia2v7678e+JLW'
+        + 'Ddv03UtWhjtrnKFRvNtBDKNpIYbZF5UZyMglFddfK8JWn7SrTTfp/Vz5jKPEPibK8I8D'
+        + 'l+Oq06X8qk7K/wDL/L/27bXXc+zfBXgbRfht4ZttF8O6PpegaPZbvs9hptpHa20G5y7b'
+        + 'I0AVcuzMcDksT1NFFFdySSsj5CpUnUm6lRtybu29W29233P/2Q==';
+      TempBlob.FromBase64String(PictureBase64);
+      TempBlob.Blob.CREATEINSTREAM(ImageStream);
+      PartId := OpenXmlWordProcessingHelper.CreateDrawingFromStream(MainDocumentPart, 6, ImageStream, 'someimage', 209550, 209550, WordDrawing);
+      WordParagraph.Create;
+      WordRun.Create;
+      WordRun.AppendDrawing(WordDrawing);
+      WordParagraph.AppendRun(WordRun);
+      WordBody.AppendParagraph(WordParagraph);
+      EXIT(PartId);
+    END;
+
+    LOCAL PROCEDURE CreateSampleHyperlink@17024440() : Text;
+    VAR
+      PartId@17024403 : Text;
+    BEGIN
+      PartId := OpenXmlWordProcessingHelper.CreateHyperLink('http://microsoft.com', 'My awesome link', MainDocumentPart, WordHyperlink);
+      WordParagraph.Create;
+      WordParagraph.AppendHyperlink(WordHyperlink);
+      WordBody.AppendParagraph(WordParagraph);
+      EXIT(PartId);
+    END;
+
+    LOCAL PROCEDURE FinalizeAndGetDocumentOuterXml@17024451() : Text;
+    BEGIN
+      MainDocumentPart.GetDocument(WordDocument);
+      WordprocessingDocument.Close;
+      EXIT(WordDocument.GetOuterXml);
+    END;
+
+    LOCAL PROCEDURE GetExampleDocxFileContentAsBase64@17024465() : Text;
+    BEGIN
+      EXIT(
+          'UEsDBBQAAAAIAPtV8kwiRWpBhQUAAB8VAAARABwAd29yZC9kb2N1bWVudC54bWwgohgAKKAUAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+        + 'A7Vjbcho5EP0V1TzbzIDBF8qQcrAdZ8txKDubd6HpAW00kiJpwNTWftk+7CftL2xLcwEcG1/iVO2Nh0EatVqnu09L0/rz9z+O39'
+        + 'zmgszBWK7kIGq3koiAZCrlcjqICpftHkZvhseLfqpYkYN0BOWl7S8G0cw53Y9jy2aQU9tSGiSOZcrk1GHXTOOFMqk2ioG1qC4Xc'
+        + 'SdJ9uOcchl5lROVLv2/9g/jH254qQzkhGtb5CRVQhliuSM0B7dDmJIWmANXGEJTrrllqJaA4K5FxoaC9fi+FjQntJgWsEMc5Lqw'
+        + 'hKcEFfiG3CGC4hLgyJyj1YYG+Ra5gZTMC6ELRx0Qwy1KC8oKu0NQNqWaT/CNMowTrYxz3CE0qWTrOPaw/dOEp75jkfdX32rKYBB'
+        + 'pgxDNHKLhGIRAsGC/FkA2VNSPcfibkLgcGG/TxlSeq1Tdq+iBKWamJFq3bW3+pLVzWqC3nrHyTojoYzZXyy/6xZNQeII8x/yMFi'
+        + 'xElBpWbAPDAgcX/TkVg+j8PMFf9CREK5Y8A5aeUQPO0Bb5QIGBpBbpyS0BQ13dUkhjJKbAjkaGhqECU8SRMhRbGKlLxL+w2iDmO'
+        + 'Whqg6rhbQCvMLegIGiWtwyXzTn2uUX6YR4Cz0CmmGUBEKpukVMlgRFKBJ8WglYvfbKZwhnMcbitEvCqkCwkKieFcIYzDph7c7AO'
+        + '4yRQ0mIOgsQ3YgdT0BZggKQFf9xcfeOWAmqTZ0D93taOSnp5C/0msujTDF0xiJJneOOcG+vIRanxZTg6r4HjBnBrTLcCcRMR/ko'
+        + '17O62e3LPpLgWvCv+wN40vOIMHtYTN6s/gOGSOye2KNiY8xwqDz/RyTbFFbK48VK9wiuedZvBv+TWjamhU0P1rGKALPJq3xVzUQ'
+        + 'smq8H3af2yXVvZTHmAPahL+lnWUeMGUS/C9ozKaTjb9/bvp9i9XPiv++RniabgjpP+75tvfOPB3e+WUuff3DudF3qnnfyL0+lHO'
+        + '+XjPzebfrRrHk6nRig1dIFKsKn7VLIZfoqlOOtTWNm33jatS1y43d1Lqu71qmt5rgWMlQ2yBgR1WBFdAJ/OEG2n197vHXa6ODSB'
+        + 'GRpyqljYSYRiXyANcwRdqsK9lyMsZsIYFUItPmJZJagOL6oI6qeEsDKqjt1mRE/LwSiY3CAntwHHsvG47uOXIXdYyl40Fp0blQ+'
+        + 'inJppSQZ0GX6MyqGAzPu57oZmM3tD1+c7unTDnVrsY5ZZcMOkVlL1N3R+DsJw63yRyhB5Jznq9RA4W67apRGQZVjnnpWiJQ9dGa'
+        + 'XwnKzZu0Acn5Q+kelb5ZzKq9dYrWMC8TREQWJ1NIisyoHndAqtnzRM6/nsav7Om8LZuUExz0Tan669ucR4W6x0R565cGI1IluLL'
+        + 'X1BaENaltzfDuB711hTdUodJVgevUCV5swVBj+zj7HV1w0sbH23Njkfc+Zt9h10RRW0ZEvQakk/LzjxGz0TwfU5F8Kb79vE9CGf'
+        + '+KS9PtzrHk6Sg72sy3rdZI8h+6y/8fDVBJeujqp5imEqy/CD/7S6FyqtKxNFSTvj2gb/I+EvrataZQR+7RyeJMlR5+3uqJeMdrv'
+        + 'JwdnuyVH3YPcgOTvoJt3D9qg9+q1kyEpBXBrjNVmHVTKb+WaGdl4jJSvhZiTedITvWV2S6zYzuf9H/Hc3kBLkluSMV9M11n7vAD'
+        + 'PONwaRQRDBYDpHuJVsLVPhKRHEFY2CxBo91/tlbpR7ezgBmi3/njNhttS45XL5xZ8vuMkrg6CxugbcMPqeTte0M0lpu82O0oOsC'
+        + '/u9V48zIjFKZWfG35U4xDOI0JL8xh991WG4XjqajfP4osZfSdZ3Lg4hwch3EOaGzKO3Lx+WhC7AZw/xk+6ep422tUqwvI2MVzed'
+        + 'w78AUEsDBAoAAAAAAPtV8kzdvdDvKgEAACoBAAALABwAX3JlbHMvLnJlbHMgohgAKKAUAAAAAAAAAAAAAAAAAAAAAAAAAAAA77u'
+        + '/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48UmVsYXRpb25zaGlwcyB4bWxucz0iaHR0cDovL3NjaGVtYX'
+        + 'Mub3BlbnhtbGZvcm1hdHMub3JnL3BhY2thZ2UvMjAwNi9yZWxhdGlvbnNoaXBzIj48UmVsYXRpb25zaGlwIFR5cGU9Imh0dHA6L'
+        + 'y9zY2hlbWFzLm9wZW54bWxmb3JtYXRzLm9yZy9vZmZpY2VEb2N1bWVudC8yMDA2L3JlbGF0aW9uc2hpcHMvb2ZmaWNlRG9jdW1l'
+        + 'bnQiIFRhcmdldD0iL3dvcmQvZG9jdW1lbnQueG1sIiBJZD0iUjE3Njg2MDlhYTI1YTQzZDIiIC8+PC9SZWxhdGlvbnNoaXBzPlB'
+        + 'LAwQUAAAACAD7VfJMpS2y0QABAAAFAwAADwAcAHdvcmQvc3R5bGVzLnhtbCCiGAAooBQAAAAAAAAAAAAAAAAAAAAAAAAAAADdkE'
+        + '1OwzAQha9ieU+dGohoVLc7JDZQiROYxE0s+U8zTtNwNRYciStgR0lXsKjEipXH7xu9N3pfH5/b/dkaclKA2jtB16uCEuVq32jXC'
+        + 'trH480D3e+2Q4VxNApJ2nZYDYJ2MYaKMaw7ZSWufFAusaMHK2P6QssGD00AXyvEZGYN40VRMiu1oxdDMlRxDErQIEG2IENHyYye'
+        + 'mhSiZD5kncW6x+jta0aCRujV5OKkzSYnaS7bJK2zzN4kqubFLfg532Zm5tQ5/gh6fQDtQcdxwZuimBkc4A8LqL3xsITwx/u7TTn'
+        + 'n4Psi3/JJYlP29E7dXNkfv64//n/64+Uv/S0T7r4BUEsDBBQAAAAIAPtV8kzPbDdeIwEAAPsCAAAcABwAd29yZC9fcmVscy9kb2'
+        + 'N1bWVudC54bWwucmVscyCiGAAooBQAAAAAAAAAAAAAAAAAAAAAAAAAAAC1krFSAyEQhl/lht7jCCSXOLmk0cLCJpMXIMtyhzngB'
+        + 'ogmz2bhI/kKMppo4ljYpGR/9uObZd9f3+bLve2LZwzReNcQVlakQAdeGdc2ZJf0zZQsF/MV9jLlG7EzQyxyi4sN6VIabimN0KGV'
+        + 'sfQDupxoH6xM+RhaOkjYyhbpqKomNJwzyCWzWB8G/A/Ra20A7zzsLLr0B5jGdOgxkmItQ4upIfTFB3WslplGigfVkFUNrAYNHBS'
+        + 'vBR9NSEGvpuR2doMhT/S31XdwJqaFqhnjgLxiAmbymmLG5t85k7KojPyqlk9DezSacjHdVDXXAsai4nBNoy6TQm/c9sfqiLUGgo'
+        + '9epxK8PaWPXuWH7/cJg5OnCcrRRknGYKZqLXAy/vSlFyu8+ABQSwMEFAAAAAgA+1XyTNORs9DlAAAA/AEAABIAHAB3b3JkL251b'
+        + 'WJlcmluZy54bWwgohgAKKAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAlZHBbgIhEIZfhZB47AIemmbj6s3ES0++AAuoJAxsgN313Tz0'
+        + 'kfoKHanbaKNNvTCZ/5/550v4PH0sVkdwZDAx2eAbKipOifEqaOv3De3z7uWNrpaLsfY9tCaiSnDBp3ps6CHnrmYsqYMBmarQGY/'
+        + 'eLkSQGdu4Z2OIuotBmZRwExybc/7KQFpPz5myTTlKld97IDfdRjeUlxE3OLQslklBkDVkFAeJWts7ZzIl7DK8NccfLxSZFb3Uqw'
+        + 'uXJFLe8znxm2ijpxw+5fjvvT+xxb+wtVEWpLvPPRPVM+Tzx+Tihpxd/eLyC1BLAwQUAAAACAD7VfJM33A5ZD4EAADtBAAADwAcA'
+        + 'G1lZGlhL2ltYWdlLmpwZyCiGAAooBQAAAAAAAAAAAAAAAAAAAAAAAAAAAD7f+P/AwYBLzdPNwZGRkaGBCBk+H+bwZmBiZERhKCA'
+        + 'mZUZBNhYWJhZ2dnY2UGYg5Obk4ODi4OdnYuXi4ubBwjYOfn4eXn4QGyQISDtIF1AxMPBzsFDMvh/gEGQg0GUQYyZUYmBSZCRWZD'
+        + 'x/xEGeQYGRlZGMGCAAkYmZhZWNqCTuLiBCrYKAJ3PzMwEdCwrCwtQthYoz8AiyCqkaOjIJhyYyK5UKGLUOHEhh7LTxoOiQRc/qB'
+        + 'gnFTVxcomJS0hKqaqpa2hqmZiamVtYWjm7uLq5e3h6BYeEhoVHREYlp6SmpWdkZhWXlJaVV1RWNbe0trV3dHZNmjxl6rTpM2bOW'
+        + 'rR4ydJly1esXLVp85at27bv2Lnr0OEjR48dP3Hy1KXLV65eu37j5q2Hjx4/efrs+YuXrz5++vzl67fvP37+AvmLkYGZEQaw+ksQ'
+        + '6C8mYBywsIP8xchUDlIgyMKqaMgm5BjInlgorGTUyCHiNHHhxoOcysZBH0STii5yiamYPFT9CPIa2GfEeayJLJ/BPYbw1y0GHmZ'
+        + 'GYOQxCzLYM/xi//bhP0PTlD9+fzfszzzt3xrPmF/6197v8tdIHZ11NtYrfobPU9/l++K7fGbrobWTVpT5z3ELkFyav2vDxzpLoE'
+        + 'avukv2G/mbSvvlf2QfjYqJv1lmbLfavKXGvTi5Oj9RJrfQpO+S6r4f008GBUrO2XZG8Zgb/0F9mYrmfxzr/zOwsl9d+yd4QWy2l'
+        + 'GdTrlKljxLnV1+56JaKr9z29yS+T87r3Ti3LSwicuLBkt+3H3//Ix78YH5Tnfir8jiO6+/2xD9aqTBN1+icrdA7DaUdhh5J0x6c'
+        + 'U5BPF9JiF9w5mf/Tyif95zKO83aFZqeFzsla9mXvzlrx+Ol/hH+vN10/v+DNpj+rGzadSDJ6taG71FLmatrd26tNP+SXPF227pZ'
+        + 'exPwPbv0/NOo2/k6psfvI3r6nfFXU/R+/D33unmh1kHXxq6qa5U8nuEsyztM0V97k0rFadVu59UbVms//Gdie/2G48uzj9j47zd'
+        + 'PqkxffvjGf69ayK/nbYjxVxINl3t+ZF3ScPeTw3+VtZ3I01q95+Orr6gRFq9+vV99d/eI/w/rgn9uP/VmsddritHjLKaFe01N3k'
+        + 'tZKeB61dI32Vl87beJ+vWkbfzH/Dq47bM9Tn5MruODj/ra1eV9FGg5mrrldv/jVNAWdhWZ++421TM490jQ/EtN0cZv28/ms9Qf3'
+        + 'xzPV6D7Kzv79er/cj0nXeG9/uesd1madPWdh4J7bjjyLMxXbbopPlTxxQlX0erz2obD5W1b7mr/8G/OzZ/ERO7VTH/qZpz9edXn'
+        + 'pn1V+p/4znP6z/9vbrdeL39xnrZB2/ZH7cHau+OFddtMXZHyL3nc+cdkt9+xctud6t5UdRIvenCmw1PEPdhUJL/LUVn6iFTLXc9'
+        + 'dU6aK8t3uj88vuF/+/CQBQSwMEFAAAAAgA+1XyTAV9750IAQAAlAIAABMAHABbQ29udGVudF9UeXBlc10ueG1sIKIYACigFAAAA'
+        + 'AAAAAAAAAAAAAAAAAAAAAAAAK2SPU7EMBCFr2K5RbEDBUIoyRZACxRcwDiTxLv+k8dZds9GwZG4ApMEpVgBEtKW9rz3vueRP98/'
+        + 'qs3BWbaHhCb4ml+KkjPwOrTG9zUfc1fc8E1TvRwjICOpx5oPOcdbKVEP4BSKEMHTpAvJqUzH1Muo9E71IK/K8lrq4DP4XOQpgzf'
+        + 'VPXRqtJk9HOh6wZKds7tFN6FqrmK0RqtMY7n37QmkCF1nNLRBj44s4i2kNqagAZF6OyvWiVPGX8zx8kdyAov/Q3+/TZBz1uBgIv'
+        + '6F2Mb+hGDctJxthH72PNH6k2mBPauUH5UjhZxeJDEfLaA4+3aW3LXzr3w/uldI5Dl/hTV6bSHnP9Z8AVBLAQItABQAAAAIAPtV8'
+        + 'kwiRWpBhQUAAB8VAAARAAAAAAAAAAAAAAAAAAAAAAB3b3JkL2RvY3VtZW50LnhtbFBLAQItAAoAAAAAAPtV8kzdvdDvKgEAACoB'
+        + 'AAALAAAAAAAAAAAAAAAAANAFAABfcmVscy8ucmVsc1BLAQItABQAAAAIAPtV8kylLbLRAAEAAAUDAAAPAAAAAAAAAAAAAAAAAD8'
+        + 'HAAB3b3JkL3N0eWxlcy54bWxQSwECLQAUAAAACAD7VfJMz2w3XiMBAAD7AgAAHAAAAAAAAAAAAAAAAACICAAAd29yZC9fcmVscy'
+        + '9kb2N1bWVudC54bWwucmVsc1BLAQItABQAAAAIAPtV8kzTkbPQ5QAAAPwBAAASAAAAAAAAAAAAAAAAAAEKAAB3b3JkL251bWJlc'
+        + 'mluZy54bWxQSwECLQAUAAAACAD7VfJM33A5ZD4EAADtBAAADwAAAAAAAAAAAAAAAAAyCwAAbWVkaWEvaW1hZ2UuanBnUEsBAi0A'
+        + 'FAAAAAgA+1XyTAV9750IAQAAlAIAABMAAAAAAAAAAAAAAAAAuQ8AAFtDb250ZW50X1R5cGVzXS54bWxQSwUGAAAAAAcABwC9AQA'
+        + 'ADhEAAAAA');
+    END;
+
+    BEGIN
+    END.
+  }
+}
+


### PR DESCRIPTION
In our add-on we do lots of existing Word documents modification and usually we use DocumentFormat.OpenXml library for that. I think some kind of direct OpenXml document modification is really needed in NAV. At least for us this is very important.

This commit contains wrappers for various Word document creation / modification tasks. Basically I tried to expose enough .NET classes to be able to do the following:
- Create empty document
- Add new paragraph with formatting options
- Add headings
- Add ordered or unordered lists
- Add table
- Add picture
- Iterate through existing test elements in document
- Modify existing text elements
It is enough to create a document as complicated as described here: http://www.ludovicperrichon.com/create-a-word-document-with-openxml-and-c/

There are a few points I need to explain that might conflict with Open C/AL Library commit requirements:
- Some wrappers depend on helper codeunit "OpenXml DotNet Helper". I needed this to call generic .NET methods like AddPart<T>. I could copy the same code to every place I needed it but I decided to move generics handling to helper codeunit. If that makes any problems, I can return to code dublication.
- OpenXml .NET library has such types as StringValue, Int32Value and so on that wraps basic .NET types to OpenXml types. I decided not to create NAV wrappers for such types. If some class has a property of such type and I need to create a setter procedure for it, as a parameter I use simple type (Text, Integer, Boolean) and assign property indirectly (for example look at Codeunit "DotNet_Word.Style" procedure "SetBasedOn").
- I added "Word." prefix in all wrapper codeunits name. I did this because DocumentFormat.OpenXml.Wordprocessing namespace contains some classes that have the same name as some .NET classes from mscorlib. This helps avoiding conflict in names.
- Codeunit "DotNet_Word.Text" have a very strange code in Create procedure. This is because I cannot call this class constructor directly - constructor has the same name as method in this class and NAV compiler resolves name to a method and not to a constructor. So to overcome this NAV limitation, I used reflection.
- Codeunin "DotNet_Wordprocessing" uses MemoryStream internally (so it is not just a simple wrapper). I need this because both InStream and OutStream are one-way only and Wordprocessing.Open method need two-way stream. So wrapper has Open procedure which accepts InStream, copies it to MemoryStream and all modifications are done here, then there is Save procedure which accepts OutStream and copies MemoryStream content to it. So it conflicts simple wrapper idea, but I think this is the right way to go, since be do not have two-way stream.