### PR TITLE
Regex 2.01 wrapper

### DIFF
--- a/BaseApp/COD3000.TXT
+++ b/BaseApp/COD3000.TXT
@@ -96,12 +96,10 @@ OBJECT Codeunit 3000 DotNet_Array
     BEGIN
       EXIT(DotNetArray.GetValue(Index));
     END;
-
     PROCEDURE GetArray@2(VAR DotNetArray2@1000 : DotNet "'mscorlib'.System.Array");
     BEGIN
       DotNetArray2 := DotNetArray
     END;
-
     PROCEDURE SetArray@3(DotNetArray2@1000 : DotNet "'mscorlib'.System.Array");
     BEGIN
       DotNetArray := DotNetArray2

--- a/BaseApp/COD3001.TXT
+++ b/BaseApp/COD3001.TXT
@@ -37,15 +37,313 @@ OBJECT Codeunit 3001 DotNet_RegEx
     BEGIN
       EXIT(DotNetRegEx.Replace(input,evaluator))
     END;
-
     PROCEDURE GetRegEx@2(VAR DotNetRegEx2@1000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Regex");
     BEGIN
       DotNetRegEx2 := DotNetRegEx
     END;
-
     PROCEDURE SetRegEx@3(DotNetRegEx2@1000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Regex");
     BEGIN
       DotNetRegEx := DotNetRegEx2
+    END;
+
+    [External]
+    PROCEDURE Regex2@1000000002(Pattern@1000000000 : Text;VAR Options@1000000003 : Codeunit 3051);
+    VAR
+      DotNetRegexOptions@1000000002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.RegexOptions";
+    BEGIN
+      Options.GetRegexOptions(DotNetRegexOptions);
+      DotNetRegEx := DotNetRegEx.Regex(Pattern, DotNetRegexOptions);
+    END;
+
+    [External]
+    PROCEDURE Regex3@1000000017(Pattern@1000000001 : Text;VAR Options@1000000000 : Codeunit 3051;MatchTimeout@1000000002 : Duration);
+    VAR
+      DotNetRegexOptions@1000000003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.RegexOptions";
+    BEGIN
+      Options.GetRegexOptions(DotNetRegexOptions);
+      DotNetRegEx := DotNetRegEx.Regex(Pattern, DotNetRegexOptions, MatchTimeout);
+    END;
+
+    [External]
+    PROCEDURE GetCacheSize@1000000006() : Integer;
+    BEGIN
+      EXIT(DotNetRegEx.CacheSize);
+    END;
+
+    [External]
+    PROCEDURE SetCacheSize@1000000007(CacheSize@1000000000 : Integer);
+    BEGIN
+      DotNetRegEx.CacheSize := CacheSize;
+    END;
+
+    [External]
+    PROCEDURE GetGroupNames@1000000026(VAR Names@1000000002 : Codeunit 3000);
+    VAR
+      DotNetNames@1000000000 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Array";
+    BEGIN
+      DotNetNames := DotNetRegEx.GetGroupNames();
+      Names.SetArray(DotNetNames);
+    END;
+
+    [External]
+    PROCEDURE GetGroupNumbers@1000000027(VAR Numbers@1000000002 : Codeunit 3000);
+    VAR
+      DotNetNumbers@1000000000 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Array";
+    BEGIN
+      DotNetNumbers := DotNetRegEx.GetGroupNumbers();
+      Numbers.SetArray(DotNetNumbers);
+    END;
+
+    [External]
+    PROCEDURE GroupNameFromNumber@1000000030(Number@1000000000 : Integer) : Text;
+    BEGIN
+      EXIT(DotNetRegEx.GroupNameFromNumber(Number));
+    END;
+
+    [External]
+    PROCEDURE GroupNumberFromName@1000000032(Name@1000000000 : Text) : Integer;
+    BEGIN
+      EXIT(DotNetRegEx.GroupNumberFromName(Name));
+    END;
+
+    [External]
+    PROCEDURE IsMatch@1000000034(Input@1000000000 : Text) : Boolean;
+    BEGIN
+      EXIT(DotNetRegEx.IsMatch(Input));
+    END;
+
+    [External]
+    PROCEDURE IsMatch2@1000000036(Input@1000000000 : Text;StartAt@1000000001 : Integer) : Boolean;
+    BEGIN
+      EXIT(DotNetRegEx.IsMatch(Input, StartAt));
+    END;
+
+    [External]
+    PROCEDURE IsMatch3@1000000038(Input@1000000000 : Text;Pattern@1000000001 : Text) : Boolean;
+    VAR
+      Regex@1000000002 : Codeunit 3001;
+    BEGIN
+      Regex.Regex(Pattern);
+      EXIT(Regex.IsMatch(Input));
+    END;
+
+    [External]
+    PROCEDURE IsMatch4@1000000041(Input@1000000001 : Text;Pattern@1000000000 : Text;VAR Options@1000000004 : Codeunit 3051) : Boolean;
+    VAR
+      Regex@1000000003 : Codeunit 3001;
+    BEGIN
+      Regex.Regex2(Pattern, Options);
+      EXIT(Regex.IsMatch(Input));
+    END;
+
+    [External]
+    PROCEDURE IsMatch5@1000000043(Input@1000000001 : Text;Pattern@1000000000 : Text;VAR Options@1000000005 : Codeunit 3051;MatchTimeout@1000000004 : Duration) : Boolean;
+    VAR
+      Regex@1000000003 : Codeunit 3001;
+    BEGIN
+      Regex.Regex3(Pattern, Options, MatchTimeout);
+      EXIT(Regex.IsMatch(Input));
+    END;
+
+    [External]
+    PROCEDURE Match@1000000000(Input@1000000000 : Text;VAR Match@1000000001 : Codeunit 3052);
+    VAR
+      DotNetMatch@1000000003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match";
+    BEGIN
+      DotNetMatch := DotNetRegEx.Match(Input);
+      Match.SetDotNetMatch(DotNetMatch);
+    END;
+
+    [External]
+    PROCEDURE Match2@1000000009(Input@1000000000 : Text;StartAt@1000000002 : Integer;VAR Match@1000000001 : Codeunit 3052);
+    VAR
+      DotNetMatch@1000000003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match";
+    BEGIN
+      DotNetMatch := DotNetRegEx.Match(Input, StartAt);
+      Match.SetDotNetMatch(DotNetMatch);
+    END;
+
+    [External]
+    PROCEDURE Match3@1000000011(Input@1000000000 : Text;Beginning@1000000002 : Integer;Length@1000000003 : Integer;VAR Match@1000000001 : Codeunit 3052);
+    VAR
+      DotNetMatch@1000000004 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match";
+    BEGIN
+      DotNetMatch := DotNetRegEx.Match(Input, Beginning, Length);
+      Match.SetDotNetMatch(DotNetMatch);
+    END;
+
+    [External]
+    PROCEDURE Match4@1000000013(Input@1000000000 : Text;Pattern@1000000002 : Text;VAR Match@1000000001 : Codeunit 3052);
+    VAR
+      Regex@1000000003 : Codeunit 3001;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Match(Input, Match);
+    END;
+
+    [External]
+    PROCEDURE Match5@1000000012(Input@1000000000 : Text;Pattern@1000000002 : Text;VAR Options@1000000005 : Codeunit 3051;VAR Match@1000000001 : Codeunit 3052);
+    VAR
+      Regex@1000000003 : Codeunit 3001;
+    BEGIN
+      Regex.Regex2(Pattern, Options);
+      Regex.Match(Input, Match);
+    END;
+
+    [External]
+    PROCEDURE Match6@1000000016(Input@1000000000 : Text;Pattern@1000000002 : Text;VAR Options@1000000006 : Codeunit 3051;MatchTimeout@1000000005 : Duration;VAR Match@1000000001 : Codeunit 3052);
+    VAR
+      Regex@1000000003 : Codeunit 3001;
+    BEGIN
+      Regex.Regex3(Pattern, Options, MatchTimeout);
+      Regex.Match(Input, Match);
+    END;
+
+    [External]
+    PROCEDURE Matches@1000000019(Input@1000000000 : Text;VAR MatchCollection@1000000001 : Codeunit 3053);
+    VAR
+      DotNetMatchCollection@1000000002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.MatchCollection";
+    BEGIN
+      DotNetMatchCollection := DotNetRegEx.Matches(Input);
+      MatchCollection.SetMatchCollection(DotNetMatchCollection);
+    END;
+
+    [External]
+    PROCEDURE Matches2@1000000010(Input@1000000000 : Text;StartAt@1000000003 : Integer;VAR MatchCollection@1000000001 : Codeunit 3053);
+    VAR
+      DotNetMatchCollection@1000000002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.MatchCollection";
+    BEGIN
+      DotNetMatchCollection := DotNetRegEx.Matches(Input, StartAt);
+      MatchCollection.SetMatchCollection(DotNetMatchCollection);
+    END;
+
+    [External]
+    PROCEDURE Matches3@1000000015(Input@1000000000 : Text;Pattern@1000000003 : Text;VAR MatchCollection@1000000001 : Codeunit 3053);
+    VAR
+      Regex@1000000004 : Codeunit 3001;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Matches(Input, MatchCollection);
+    END;
+
+    [External]
+    PROCEDURE Matches4@1000000014(Input@1000000000 : Text;Pattern@1000000003 : Text;VAR Options@1000000005 : Codeunit 3051;VAR MatchCollection@1000000001 : Codeunit 3053);
+    VAR
+      Regex@1000000004 : Codeunit 3001;
+    BEGIN
+      Regex.Regex2(Pattern, Options);
+      Regex.Matches(Input, MatchCollection);
+    END;
+
+    [External]
+    PROCEDURE Matches5@1000000022(Input@1000000000 : Text;Pattern@1000000003 : Text;VAR Options@1000000006 : Codeunit 3051;MatchTimeout@1000000005 : Duration;VAR MatchCollection@1000000001 : Codeunit 3053);
+    VAR
+      Regex@1000000004 : Codeunit 3001;
+    BEGIN
+      Regex.Regex3(Pattern, Options, MatchTimeout);
+      Regex.Matches(Input, MatchCollection);
+    END;
+
+    [External]
+    PROCEDURE Replace2@1000000031(Input@1000000000 : Text;Replacement@1000000001 : Text;Count@1000000002 : Integer) : Text;
+    BEGIN
+      EXIT(DotNetRegEx.Replace(Input, Replacement, Count));
+    END;
+
+    [External]
+    PROCEDURE Replace3@1000000035(Input@1000000000 : Text;Replacement@1000000001 : Text;Count@1000000002 : Integer;StartAt@1000000003 : Integer) : Text;
+    BEGIN
+      EXIT(DotNetRegEx.Replace(Input, Replacement, Count, StartAt));
+    END;
+
+    [External]
+    PROCEDURE Replace4@1000000039(Input@1000000000 : Text;Pattern@1000000002 : Text;Replacement@1000000001 : Text) : Text;
+    VAR
+      Regex@1000000003 : Codeunit 3001;
+    BEGIN
+      Regex.Regex(Pattern);
+      EXIT(Regex.Replace(Input, Replacement));
+    END;
+
+    [External]
+    PROCEDURE Replace5@1000000008(Input@1000000000 : Text;Pattern@1000000002 : Text;Replacement@1000000001 : Text;VAR Options@1000000005 : Codeunit 3051) : Text;
+    VAR
+      Regex@1000000003 : Codeunit 3001;
+    BEGIN
+      Regex.Regex2(Pattern, Options);
+      EXIT(Regex.Replace(Input, Replacement));
+    END;
+
+    [External]
+    PROCEDURE Replace6@1000000023(Input@1000000000 : Text;Pattern@1000000002 : Text;Replacement@1000000001 : Text;VAR Options@1000000006 : Codeunit 3051;MatchTimeout@1000000005 : Duration) : Text;
+    VAR
+      Regex@1000000003 : Codeunit 3001;
+    BEGIN
+      Regex.Regex3(Pattern, Options, MatchTimeout);
+      EXIT(Regex.Replace(Input, Replacement));
+    END;
+
+    [External]
+    PROCEDURE Split2@1000000033(Input@1000000000 : Text;VAR Strings@1000000001 : Codeunit 3000);
+    VAR
+      StringsDotNetArray@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Array";
+    BEGIN
+      StringsDotNetArray := DotNetRegEx.Split(Input);
+      Strings.SetArray(StringsDotNetArray);
+    END;
+
+    [External]
+    PROCEDURE Split3@1000000044(Input@1000000000 : Text;Count@1000000003 : Integer;VAR Strings@1000000001 : Codeunit 3000);
+    VAR
+      StringsDotNetArray@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Array";
+    BEGIN
+      StringsDotNetArray := DotNetRegEx.Split(Input, Count);
+      Strings.SetArray(StringsDotNetArray);
+    END;
+
+    [External]
+    PROCEDURE Split4@1000000046(Input@1000000000 : Text;Count@1000000003 : Integer;StartAt@1000000004 : Integer;VAR Strings@1000000001 : Codeunit 3000);
+    VAR
+      StringsDotNetArray@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Array";
+    BEGIN
+      StringsDotNetArray := DotNetRegEx.Split(Input, Count, StartAt);
+      Strings.SetArray(StringsDotNetArray);
+    END;
+
+    [External]
+    PROCEDURE Split5@1000000018(Input@1000000000 : Text;Pattern@1000000003 : Text;VAR Options@1000000005 : Codeunit 3051;VAR Strings@1000000001 : Codeunit 3000);
+    VAR
+      Regex@1000000004 : Codeunit 3001;
+    BEGIN
+      Regex.Regex2(Pattern, Options);
+      Regex.Split2(Input, Strings);
+    END;
+
+    [External]
+    PROCEDURE Split6@1000000029(Input@1000000000 : Text;Pattern@1000000003 : Text;VAR Options@1000000006 : Codeunit 3051;MatchTimeout@1000000005 : Duration;VAR Strings@1000000001 : Codeunit 3000);
+    VAR
+      Regex@1000000004 : Codeunit 3001;
+    BEGIN
+      Regex.Regex3(Pattern, Options, MatchTimeout);
+      Regex.Split2(Input, Strings);
+    END;
+
+    [External]
+    PROCEDURE GetHashCode@1000000028() : Integer;
+    BEGIN
+      EXIT(DotNetRegEx.GetHashCode());
+    END;
+
+    [External]
+    PROCEDURE Escape@1000000021(String@1000000000 : Text) : Text;
+    BEGIN
+      EXIT(DotNetRegEx.Escape(String));
+    END;
+
+    [External]
+    PROCEDURE Unescape@1000000048(String@1000000000 : Text) : Text;
+    BEGIN
+      EXIT(DotNetRegEx.Unescape(String));
     END;
 
     BEGIN

--- a/BaseApp/COD3051.TXT
+++ b/BaseApp/COD3051.TXT
@@ -1,0 +1,209 @@
+OBJECT Codeunit 3051 DotNet_RegexOptions
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetRegexOptions@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.RegexOptions";
+
+    [External]
+    PROCEDURE Compiled@1000000009() : Integer;
+    BEGIN
+      DotNetRegexOptions := DotNetRegexOptions.Compiled;
+      EXIT(DotNetRegexOptions);
+    END;
+
+    [External]
+    PROCEDURE CultureInvariant@1000000017() : Integer;
+    BEGIN
+      DotNetRegexOptions := DotNetRegexOptions.CultureInvariant;
+      EXIT(DotNetRegexOptions);
+    END;
+
+    [External]
+    PROCEDURE ECMAScript@1000000018() : Integer;
+    BEGIN
+      DotNetRegexOptions := DotNetRegexOptions.ECMAScript;
+      EXIT(DotNetRegexOptions);
+    END;
+
+    [External]
+    PROCEDURE ExplicitCapture@1000000019() : Integer;
+    BEGIN
+      DotNetRegexOptions := DotNetRegexOptions.ExplicitCapture;
+      EXIT(DotNetRegexOptions);
+    END;
+
+    [External]
+    PROCEDURE IgnoreCase@1000000020() : Integer;
+    BEGIN
+      DotNetRegexOptions := DotNetRegexOptions.IgnoreCase;
+      EXIT(DotNetRegexOptions);
+    END;
+
+    [External]
+    PROCEDURE IgnorePatternWhitespace@1000000021() : Integer;
+    BEGIN
+      DotNetRegexOptions := DotNetRegexOptions.IgnorePatternWhitespace;
+      EXIT(DotNetRegexOptions);
+    END;
+
+    [External]
+    PROCEDURE Multiline@1000000022() : Integer;
+    BEGIN
+      DotNetRegexOptions := DotNetRegexOptions.Multiline;
+      EXIT(DotNetRegexOptions);
+    END;
+
+    [External]
+    PROCEDURE None@100000028() : Integer;
+    BEGIN
+      DotNetRegexOptions := DotNetRegexOptions.None;
+      EXIT(DotNetRegexOptions);
+    END;
+
+    [External]
+    PROCEDURE RightToLeft@1000000024() : Integer;
+    BEGIN
+      DotNetRegexOptions := DotNetRegexOptions.RightToLeft;
+      EXIT(DotNetRegexOptions);
+    END;
+
+    [External]
+    PROCEDURE Singleline@1000000025() : Integer;
+    BEGIN
+      DotNetRegexOptions := DotNetRegexOptions.Singleline;
+      EXIT(DotNetRegexOptions);
+    END;
+
+    [External]
+    PROCEDURE BitwiseOr@100000016(Option1@100000000 : Integer;Option2@100000001 : Integer) : Integer;
+    VAR
+      Bits1@100000002 : ARRAY [32] OF Integer;
+      Bits2@100000003 : ARRAY [32] OF Integer;
+      Position@100000005 : Integer;
+      Result@100000004 : Integer;
+      ResultBits@100000006 : ARRAY [32] OF Integer;
+    BEGIN
+      IntegerToBits(Option1, Bits1);
+      IntegerToBits(Option2, Bits2);
+      FOR Position := 1 TO 32 DO BEGIN
+        IF ((Bits1[Position] = 1) OR (Bits2[Position] = 1)) THEN BEGIN
+          ResultBits[Position] := 1;
+        END;
+      END;
+      Result := BitsToInteger(ResultBits);
+      DotNetRegexOptions := Result;
+      EXIT(Result);
+    END;
+
+    [External]
+    PROCEDURE BitwiseAnd@100000025(Option1@100000000 : Integer;Option2@100000001 : Integer) : Integer;
+    VAR
+      Bits1@100000002 : ARRAY [32] OF Integer;
+      Bits2@100000003 : ARRAY [32] OF Integer;
+      Position@100000005 : Integer;
+      Result@100000004 : Integer;
+      ResultBits@100000006 : ARRAY [32] OF Integer;
+    BEGIN
+      IntegerToBits(Option1, Bits1);
+      IntegerToBits(Option2, Bits2);
+      FOR Position := 1 TO 32 DO BEGIN
+        IF ((Bits1[Position] = 1) AND (Bits2[Position] = 1)) THEN BEGIN
+          ResultBits[Position] := 1;
+        END;
+      END;
+      Result := BitsToInteger(ResultBits);
+      DotNetRegexOptions := Result;
+      EXIT(Result);
+    END;
+
+    [External]
+    PROCEDURE BitwiseXor@100000026(Option1@100000000 : Integer;Option2@100000001 : Integer) : Integer;
+    VAR
+      Bits1@100000002 : ARRAY [32] OF Integer;
+      Bits2@100000003 : ARRAY [32] OF Integer;
+      Position@100000005 : Integer;
+      Result@100000004 : Integer;
+      ResultBits@100000006 : ARRAY [32] OF Integer;
+    BEGIN
+      IntegerToBits(Option1, Bits1);
+      IntegerToBits(Option2, Bits2);
+      FOR Position := 1 TO 32 DO BEGIN
+        IF (Bits1[Position] <> Bits2[Position]) THEN BEGIN
+          ResultBits[Position] := 1;
+        END;
+      END;
+      Result := BitsToInteger(ResultBits);
+      DotNetRegexOptions := Result;
+      EXIT(Result);
+    END;
+
+    [External]
+    PROCEDURE ToString@100000000() : Text;
+    BEGIN
+      EXIT(DotNetRegexOptions.ToString());
+    END;
+
+    [External]
+    PROCEDURE ToInteger@100000006() : Integer;
+    BEGIN
+      EXIT(DotNetRegexOptions);
+    END;
+    PROCEDURE GetRegexOptions@1000000002(VAR DotNetRegexOptions2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.RegexOptions");
+    VAR
+      String@1000000002 : Text;
+    BEGIN
+      DotNetRegexOptions2 := DotNetRegexOptions;
+    END;
+    PROCEDURE SetRegexOptions@1000000004(VAR DotNetRegexOptions2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.RegexOptions");
+    VAR
+      String@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.String";
+      Separators@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.String";
+      StringParts@1000000003 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Array";
+      StringPart@1000000004 : Text;
+      IntegerValue@1000000005 : Integer;
+    BEGIN
+      DotNetRegexOptions := DotNetRegexOptions2;
+    END;
+    LOCAL PROCEDURE IntegerToBits@100000004(Integer@100000000 : Integer;VAR Bits@100000002 : ARRAY [32] OF Integer);
+    VAR
+      Position@100000001 : Integer;
+    BEGIN
+      CLEAR(Bits);
+      Position := 32;
+      WHILE (Integer > 0) DO BEGIN
+        Bits[Position] := Integer MOD 2;
+        Integer := Integer DIV 2;
+        Position -= 1;
+      END;
+    END;
+    LOCAL PROCEDURE BitsToInteger@100000005(Bits@100000000 : ARRAY [32] OF Integer) : Integer;
+    VAR
+      Integer@100000001 : Integer;
+      Position@100000002 : Integer;
+    BEGIN
+      CLEAR(Integer);
+      FOR Position := 1 TO 32 DO BEGIN
+        Integer *= 2;
+        Integer += Bits[Position];
+      END;
+      EXIT(Integer);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD3052.TXT
+++ b/BaseApp/COD3052.TXT
@@ -1,0 +1,123 @@
+OBJECT Codeunit 3052 DotNet_Match
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetMatch@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match";
+
+    [External]
+    PROCEDURE Groups@1000000003(VAR Groups@1000000000 : Codeunit 3055);
+    VAR
+      DotNetGroups@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.GroupCollection";
+    BEGIN
+      DotNetGroups := DotNetMatch.Groups;
+      Groups.SetGroupCollection(DotNetGroups);
+    END;
+
+    [External]
+    PROCEDURE Index@1000000006() : Integer;
+    BEGIN
+      EXIT(DotNetMatch.Index);
+    END;
+
+    [External]
+    PROCEDURE Length@1000000005() : Integer;
+    BEGIN
+      EXIT(DotNetMatch.Length);
+    END;
+
+    [External]
+    PROCEDURE Name@1000000007() : Text;
+    BEGIN
+      EXIT(DotNetMatch.Name);
+    END;
+
+    [External]
+    PROCEDURE Success@1000000008() : Boolean;
+    BEGIN
+      EXIT(DotNetMatch.Success);
+    END;
+
+    [External]
+    PROCEDURE Value@1000000009() : Text;
+    BEGIN
+      EXIT(DotNetMatch.Value);
+    END;
+
+    [External]
+    PROCEDURE Equals@1000000010(VAR Match@1000000001 : Codeunit 3052) : Boolean;
+    VAR
+      DotNetMatch2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match";
+    BEGIN
+      Match.GetDotNetMatch(DotNetMatch2);
+      EXIT(DotNetMatch.Equals(DotNetMatch2));
+    END;
+
+    [External]
+    PROCEDURE GetHashCode@1000000012() : Integer;
+    BEGIN
+      EXIT(DotNetMatch.GetHashCode());
+    END;
+
+    [External]
+    PROCEDURE NextMatch@1000000011(VAR NextMatch@1000000000 : Codeunit 3052);
+    VAR
+      NextDotNetMatch@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match";
+    BEGIN
+      NextDotNetMatch := DotNetMatch.NextMatch();
+      NextMatch.SetDotNetMatch(NextDotNetMatch);
+    END;
+
+    [External]
+    PROCEDURE Result@1000000013(Replacement@1000000000 : Text) : Text;
+    BEGIN
+      EXIT(DotNetMatch.Result(Replacement));
+    END;
+
+    [External]
+    PROCEDURE Synchronized@1000000014(VAR InnerMatch@1000000000 : Codeunit 3052;VAR SynchronizedMatch@1000000001 : Codeunit 3052);
+    VAR
+      DotNetInnerMatch@1000000002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match";
+      DotNetSynchronizedMatch@1000000003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match";
+    BEGIN
+      InnerMatch.GetDotNetMatch(DotNetInnerMatch);
+      DotNetSynchronizedMatch := DotNetMatch.Synchronized(DotNetInnerMatch);
+      SynchronizedMatch.SetDotNetMatch(DotNetSynchronizedMatch);
+    END;
+
+    [External]
+    PROCEDURE Synchronized2@1000000027(VAR InnerGroup@1000000000 : Codeunit 3054;VAR SynchronizedGroup@1000000003 : Codeunit 3054);
+    VAR
+      DotNetInnerGroup@1000000002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Group";
+      DotNetSynchronizedGroup@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Group";
+    BEGIN
+      InnerGroup.GetGroup(DotNetInnerGroup);
+      DotNetSynchronizedGroup := DotNetMatch.Synchronized(DotNetInnerGroup);
+      SynchronizedGroup.SetGroup(DotNetSynchronizedGroup);
+    END;
+    PROCEDURE GetDotNetMatch@1000000028(VAR DotNetMatch2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match");
+    BEGIN
+      DotNetMatch2 := DotNetMatch;
+    END;
+    PROCEDURE SetDotNetMatch@1000000000(VAR DotNetMatch2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match");
+    BEGIN
+      DotNetMatch := DotNetMatch2;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD3053.TXT
+++ b/BaseApp/COD3053.TXT
@@ -1,0 +1,71 @@
+OBJECT Codeunit 3053 DotNet_MatchCollection
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetMatchCollection@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.MatchCollection";
+
+    [External]
+    PROCEDURE Count@1000000004() : Integer;
+    BEGIN
+      EXIT(DotNetMatchCollection.Count);
+    END;
+
+    [External]
+    PROCEDURE Item@1000000005(Index@1000000002 : Integer;VAR Match@1000000001 : Codeunit 3052);
+    VAR
+      DotNetMatch@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.MatchCollection";
+    BEGIN
+      DotNetMatch := DotNetMatchCollection.Item(Index);
+      Match.SetDotNetMatch(DotNetMatch);
+    END;
+
+    [External]
+    PROCEDURE CopyTo@1000000010(VAR Matches@1000000000 : Codeunit 3053;Index@1000000002 : Integer);
+    VAR
+      DotNetMatches@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.MatchCollection";
+    BEGIN
+      DotNetMatchCollection.CopyTo(DotNetMatches, Index);
+      Matches.SetMatchCollection(DotNetMatches);
+    END;
+
+    [External]
+    PROCEDURE Equals@1000000012(VAR Matches@1000000000 : Codeunit 3053) : Boolean;
+    VAR
+      DotNetMatches@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.MatchCollection";
+    BEGIN
+      Matches.GetMatchCollection(DotNetMatches);
+      EXIT(DotNetMatchCollection.Equals(DotNetMatches));
+    END;
+
+    [External]
+    PROCEDURE GetHashCode@1000000013() : Integer;
+    BEGIN
+      EXIT(DotNetMatchCollection.GetHashCode());
+    END;
+    PROCEDURE GetMatchCollection@1000000002(VAR DotNetMatchCollection2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.MatchCollection");
+    BEGIN
+      DotNetMatchCollection2 := DotNetMatchCollection;
+    END;
+    PROCEDURE SetMatchCollection@1000000000(VAR DotNetMatchCollection2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.MatchCollection");
+    BEGIN
+      DotNetMatchCollection := DotNetMatchCollection2;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD3054.TXT
+++ b/BaseApp/COD3054.TXT
@@ -1,0 +1,108 @@
+OBJECT Codeunit 3054 DotNet_Group
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetGroup@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Group";
+
+    [External]
+    PROCEDURE Captures@1000000002(VAR Captures@1000000000 : Codeunit 3057);
+    VAR
+      DotNetCaptures@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.CaptureCollection";
+    BEGIN
+      DotNetCaptures := DotNetGroup.Captures;
+      Captures.SetCaptureCollection(DotNetCaptures);
+    END;
+
+    [External]
+    PROCEDURE Index@1000000006() : Integer;
+    BEGIN
+      EXIT(DotNetGroup.Index);
+    END;
+
+    [External]
+    PROCEDURE Length@1000000005() : Integer;
+    BEGIN
+      EXIT(DotNetGroup.Length);
+    END;
+
+    [External]
+    PROCEDURE Name@1000000007() : Text;
+    BEGIN
+      EXIT(DotNetGroup.Name);
+    END;
+
+    [External]
+    PROCEDURE Success@1000000008() : Boolean;
+    BEGIN
+      EXIT(DotNetGroup.Success);
+    END;
+
+    [External]
+    PROCEDURE Value@1000000009() : Text;
+    BEGIN
+      EXIT(DotNetGroup.Value);
+    END;
+
+    [External]
+    PROCEDURE Equals@1000000014(VAR Group@1000000000 : Codeunit 3054) : Boolean;
+    VAR
+      DotNetGroup2@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match";
+    BEGIN
+      Group.GetGroup(DotNetGroup2);
+      EXIT(DotNetGroup.Equals(DotNetGroup2));
+    END;
+
+    [External]
+    PROCEDURE Equals2@1000000003(GroupA@1000000000 : Codeunit 3054;GroupB@1000000001 : Codeunit 3054) : Boolean;
+    VAR
+      DotNetGroupA@1000000002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Group";
+      DotNetGroupB@1000000003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Group";
+    BEGIN
+      GroupA.GetGroup(DotNetGroupA);
+      GroupB.GetGroup(DotNetGroupB);
+      EXIT(DotNetGroup.Equals(DotNetGroupA, DotNetGroupB));
+    END;
+
+    [External]
+    PROCEDURE GetHashCode@1000000012() : Integer;
+    BEGIN
+      EXIT(DotNetGroup.GetHashCode());
+    END;
+
+    [External]
+    PROCEDURE Synchronized@1000000011(VAR InnerGroup@1000000000 : Codeunit 3054;VAR SynchronizedGroup@1000000002 : Codeunit 3054);
+    VAR
+      InnerGroupObject@1000000003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match";
+      SynchronizedGroupObject@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Match";
+    BEGIN
+      InnerGroup.GetGroup(InnerGroupObject);
+      SynchronizedGroupObject := DotNetGroup.Synchronized(InnerGroupObject);
+      SynchronizedGroup.SetGroup(SynchronizedGroupObject);
+    END;
+    PROCEDURE GetGroup@1000000001(VAR DotNetGroup2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Group");
+    BEGIN
+      DotNetGroup2 := DotNetGroup;
+    END;
+    PROCEDURE SetGroup@1000000000(VAR DotNetGroup2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Group");
+    BEGIN
+      DotNetGroup := DotNetGroup2;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD3055.TXT
+++ b/BaseApp/COD3055.TXT
@@ -1,0 +1,91 @@
+OBJECT Codeunit 3055 DotNet_GroupCollection
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetGroupCollection@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.GroupCollection";
+
+    [External]
+    PROCEDURE Count@1000000004() : Integer;
+    BEGIN
+      EXIT(DotNetGroupCollection.Count);
+    END;
+
+    [External]
+    PROCEDURE Item@1000000009(GroupNumber@1000000000 : Integer;VAR Group@1000000002 : Codeunit 3054);
+    VAR
+      DotNetGroup@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Group";
+    BEGIN
+      DotNetGroup := DotNetGroupCollection.Item(GroupNumber);
+      Group.SetGroup(DotNetGroup);
+    END;
+
+    [External]
+    PROCEDURE ItemGroupName@1000000010(GroupName@1000000000 : Text;VAR Group@1000000001 : Codeunit 3054);
+    VAR
+      DotNetGroup@1000000002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Group";
+    BEGIN
+      DotNetGroup := DotNetGroupCollection.Item(GroupName);
+      Group.SetGroup(DotNetGroup);
+    END;
+
+    [External]
+    PROCEDURE CopyTo@1000000013(VAR Groups@1000000000 : Codeunit 3055;Index@1000000002 : Integer) : Integer;
+    VAR
+      DotNetGroups@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.GroupCollection";
+    BEGIN
+      DotNetGroupCollection.CopyTo(DotNetGroups, Index);
+      Groups.SetGroupCollection(DotNetGroups);
+    END;
+
+    [External]
+    PROCEDURE Equals@1000000016(VAR Groups@1000000000 : Codeunit 3055) : Boolean;
+    VAR
+      DotNetGroups@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.GroupCollection";
+    BEGIN
+      Groups.GetGroupCollection(DotNetGroups);
+      EXIT(DotNetGroupCollection.Equals(DotNetGroups));
+    END;
+
+    [External]
+    PROCEDURE Equals2@1000000002(VAR GroupsA@1000000000 : Codeunit 3055;VAR GroupsB@1000000001 : Codeunit 3055) : Boolean;
+    VAR
+      DotNetGroupsA@1000000002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.GroupCollection";
+      DotNetGroupsB@1000000003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.GroupCollection";
+    BEGIN
+      GroupsA.GetGroupCollection(DotNetGroupsA);
+      GroupsB.GetGroupCollection(DotNetGroupsB);
+      EXIT(DotNetGroupCollection.Equals(DotNetGroupsA, DotNetGroupsB));
+    END;
+
+    [External]
+    PROCEDURE GetHashCode@1000000017() : Integer;
+    BEGIN
+      EXIT(DotNetGroupCollection.GetHashCode());
+    END;
+    PROCEDURE GetGroupCollection@1000000001(VAR DotNetGroupCollection2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.GroupCollection");
+    BEGIN
+      DotNetGroupCollection2 := DotNetGroupCollection;
+    END;
+    PROCEDURE SetGroupCollection@1000000000(VAR DotNetGroupCollection2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.GroupCollection");
+    BEGIN
+      DotNetGroupCollection := DotNetGroupCollection2;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD3056.TXT
+++ b/BaseApp/COD3056.TXT
@@ -1,0 +1,73 @@
+OBJECT Codeunit 3056 DotNet_Capture
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetCapture@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Capture";
+
+    [External]
+    PROCEDURE Index@1000000002() : Integer;
+    BEGIN
+      EXIT(DotNetCapture.Index);
+    END;
+
+    [External]
+    PROCEDURE Length@1000000003() : Integer;
+    BEGIN
+      EXIT(DotNetCapture.Length);
+    END;
+
+    [External]
+    PROCEDURE Value@1000000004() : Text;
+    BEGIN
+      EXIT(DotNetCapture.Value);
+    END;
+
+    [External]
+    PROCEDURE Equals@1000000005(Value@1000000000 : Text) : Boolean;
+    BEGIN
+      EXIT(DotNetCapture.Equals(Value));
+    END;
+
+    [External]
+    PROCEDURE Equals2@1000000006(VAR CaptureA@1000000000 : Codeunit 3056;VAR CaptureB@1000000001 : Codeunit 3056) : Boolean;
+    VAR
+      DotNetCaptureA@1000000002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Capture";
+      DotNetCaptureB@1000000003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Capture";
+    BEGIN
+      CaptureA.GetCapture(DotNetCaptureA);
+      CaptureB.GetCapture(DotNetCaptureB);
+      EXIT(DotNetCapture.Equals(DotNetCaptureA, DotNetCaptureB));
+    END;
+
+    [External]
+    PROCEDURE GetHashCode@1000000007() : Integer;
+    BEGIN
+      EXIT(DotNetCapture.GetHashCode());
+    END;
+    PROCEDURE GetCapture@1000000001(VAR DotNetCapture2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Capture");
+    BEGIN
+      DotNetCapture2 := DotNetCapture;
+    END;
+    PROCEDURE SetCapture@1000000000(VAR DotNetCapture2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Capture");
+    BEGIN
+      DotNetCapture := DotNetCapture2;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/BaseApp/COD3057.TXT
+++ b/BaseApp/COD3057.TXT
@@ -1,0 +1,92 @@
+OBJECT Codeunit 3057 DotNet_CaptureCollection
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      DotNetCaptureCollection@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.CaptureCollection";
+
+    [External]
+    PROCEDURE Count@1000000002() : Integer;
+    BEGIN
+      EXIT(DotNetCaptureCollection.Count);
+    END;
+
+    [External]
+    PROCEDURE IsReadOnly@1000000003() : Boolean;
+    BEGIN
+      EXIT(DotNetCaptureCollection.IsReadOnly);
+    END;
+
+    [External]
+    PROCEDURE IsSynchronized@1000000004() : Boolean;
+    BEGIN
+      EXIT(DotNetCaptureCollection.IsSynchronized);
+    END;
+
+    [External]
+    PROCEDURE Item@1000000005(CaptureNumber@1000000001 : Integer;VAR Capture@1000000000 : Codeunit 3056);
+    VAR
+      DotNetCapture@1000000002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Capture";
+    BEGIN
+      DotNetCapture := DotNetCaptureCollection.Item(CaptureNumber);
+      Capture.SetCapture(DotNetCapture);
+    END;
+    LOCAL PROCEDURE CopyTo@1000000009(VAR Captures@1000000000 : Codeunit 3057;Index@1000000002 : Integer);
+    VAR
+      DotNetCaptures@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.CaptureCollection";
+    BEGIN
+      DotNetCaptureCollection.CopyTo(DotNetCaptures, Index);
+      Captures.SetCaptureCollection(DotNetCaptures);
+    END;
+
+    [External]
+    PROCEDURE Equals@1000000010(VAR Capture@1000000000 : Codeunit 3056) : Boolean;
+    VAR
+      DotNetCapture@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.Capture";
+    BEGIN
+      Capture.GetCapture(DotNetCapture);
+      EXIT(DotNetCaptureCollection.Equals(DotNetCapture));
+    END;
+
+    [External]
+    PROCEDURE Equals2@1000000006(VAR CapturesA@1000000000 : Codeunit 3057;VAR CapturesB@1000000001 : Codeunit 3057) : Boolean;
+    VAR
+      DotNetCapturesA@1000000002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.CaptureCollection";
+      DotNetCapturesB@1000000003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.CaptureCollection";
+    BEGIN
+      CapturesA.GetCaptureCollection(DotNetCapturesA);
+      CapturesB.GetCaptureCollection(DotNetCapturesB);
+      EXIT(DotNetCaptureCollection.Equals(DotNetCapturesA, DotNetCapturesB));
+    END;
+
+    [External]
+    PROCEDURE GetHashCode@1000000012() : Integer;
+    BEGIN
+      EXIT(DotNetCaptureCollection.GetHashCode());
+    END;
+    PROCEDURE GetCaptureCollection@1000000001(VAR DotNetCaptureCollection2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.CaptureCollection");
+    BEGIN
+      DotNetCaptureCollection2 := DotNetCaptureCollection;
+    END;
+    PROCEDURE SetCaptureCollection@1000000000(VAR DotNetCaptureCollection2@1000000000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Text.RegularExpressions.CaptureCollection");
+    BEGIN
+      DotNetCaptureCollection := DotNetCaptureCollection2;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/Test/COD145900.TXT
+++ b/Test/COD145900.TXT
@@ -1,0 +1,27 @@
+OBJECT Codeunit 145900 Test_DotNet_Regex_Runner
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    Subtype=TestRunner;
+    TestIsolation=Function;
+    OnRun=BEGIN
+            CODEUNIT.RUN(CODEUNIT::Test_DotNet_Regex);
+            CODEUNIT.RUN(CODEUNIT::Test_DotNet_MatchGroupCapture);
+            CODEUNIT.RUN(CODEUNIT::Test_DotNet_Array);
+          END;
+
+  }
+  CODE
+  {
+
+    BEGIN
+    END.
+  }
+}
+

--- a/Test/COD145901.TXT
+++ b/Test/COD145901.TXT
@@ -1,0 +1,677 @@
+OBJECT Codeunit 145901 Test_DotNet_Regex
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    Subtype=Test;
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      TestToolkit@1000000000 : Codeunit 145904;
+
+    [Test]
+    PROCEDURE TestIsMatch@1000000000();
+    VAR
+      Pattern@1000000000 : Text;
+    BEGIN
+      Pattern := '[a-zA-Z0-9]\d{2}[a-zA-Z0-9](-\d{3}){2}[A-Za-z0-9]';
+      TestIsMatchOnce('1298-673-4192', Pattern, TRUE);
+      TestIsMatchOnce('A08Z-931-468A', Pattern, TRUE);
+      TestIsMatchOnce('_A90-123-129X', Pattern, FALSE);
+      TestIsMatchOnce('12345-KKA-1230', Pattern, FALSE);
+      TestIsMatchOnce('0919-2893-1256', Pattern, FALSE);
+    END;
+    LOCAL PROCEDURE TestIsMatchOnce@1000000002(Input@1000000001 : Text;Pattern@1000000000 : Text;ExpectedResult@1000000002 : Boolean);
+    VAR
+      Regex@1000000006 : Codeunit 3001;
+      Result@1000000004 : Boolean;
+    BEGIN
+      Regex.Regex(Pattern);
+      Result := Regex.IsMatch(Input);
+      TestToolkit.VerifyBooleanResult(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Result, ExpectedResult);
+    END;
+
+    [Test]
+    PROCEDURE TestIsMatch2@1000000004();
+    VAR
+      Pattern@1000000000 : Text;
+    BEGIN
+      Pattern := '[A-Z0-9]\d{2}[A-Z0-9](-\d{3}){2}[A-Z0-9]';
+      TestIsMatch2Once('Part Number: 1298-673-4192', Pattern, 11, TRUE);
+      TestIsMatch2Once('Part Number: 1298-673-4192', Pattern, 18, FALSE);
+      TestIsMatch2Once('Part No: A08Z-931-468A', Pattern, 7, TRUE);
+      TestIsMatch2Once('Part No: A08Z-931-468A', Pattern, 15, FALSE);
+      TestIsMatch2Once('_A90-123-129X', Pattern, 0, FALSE);
+      TestIsMatch2Once('123K-000-AA30', Pattern, 0, FALSE);
+      TestIsMatch2Once('SKU: 0919-289-1256', Pattern, 3, TRUE);
+      TestIsMatch2Once('SKU: 0919-289-1256', Pattern, 10, FALSE);
+    END;
+    LOCAL PROCEDURE TestIsMatch2Once@1000000005(Input@1000000005 : Text;Pattern@1000000004 : Text;StartAt@1000000006 : Integer;ExpectedResult@1000000003 : Boolean);
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Result@1000000000 : Boolean;
+    BEGIN
+      Regex.Regex(Pattern);
+      Result := Regex.IsMatch2(Input, StartAt);
+      TestToolkit.VerifyBooleanResult(TestToolkit.ArgsToString3('Input', Input, 'StartAt', StartAt, 'Pattern', Pattern), Result, ExpectedResult);
+    END;
+
+    [Test]
+    PROCEDURE TestIsMatch3@1000000003();
+    VAR
+      Pattern@1000000000 : Text;
+    BEGIN
+      Pattern := '[A-Z0-9]\d{2}[A-Z0-9](-\d{3}){2}[A-Z0-9]';
+      TestIsMatch3Once('1298-673-4192', Pattern, TRUE);
+      TestIsMatch3Once('A08Z-931-468A', Pattern, TRUE);
+      TestIsMatch3Once('_A90-123-129X', Pattern, FALSE);
+      TestIsMatch3Once('12345-KKA-1230', Pattern, FALSE);
+      TestIsMatch3Once('0919-2893-1256', Pattern, FALSE);
+    END;
+    LOCAL PROCEDURE TestIsMatch3Once@1000000006(Input@1000000002 : Text;Pattern@1000000003 : Text;ExpectedResult@1000000004 : Boolean);
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Result@1000000000 : Boolean;
+    BEGIN
+      Result := Regex.IsMatch3(Input, Pattern);
+      TestToolkit.VerifyBooleanResult(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Result, ExpectedResult);
+    END;
+
+    [Test]
+    PROCEDURE TestIsMatch4@1000000011();
+    VAR
+      Pattern@1000000000 : Text;
+      Options@1000000001 : Codeunit 3051;
+    BEGIN
+      Pattern := '[A-Z0-9]\d{2}[A-Z0-9](-\d{3}){2}[A-Z0-9]';
+      Options.IgnoreCase();
+      TestIsMatch4Once('1298-673-4192', Pattern, Options, TRUE);
+      TestIsMatch4Once('A08Z-931-468a', Pattern, Options, TRUE);
+      TestIsMatch4Once('_A90-123-129X', Pattern, Options, FALSE);
+      TestIsMatch4Once('12345-KKA-1230', Pattern, Options, FALSE);
+      TestIsMatch4Once('0919-2893-1256', Pattern, Options, FALSE);
+    END;
+    LOCAL PROCEDURE TestIsMatch4Once@1000000012(Input@1000000002 : Text;Pattern@1000000001 : Text;VAR Options@1000000003 : Codeunit 3051;ExpectedResult@1000000000 : Boolean);
+    VAR
+      Regex@1000000005 : Codeunit 3001;
+      Result@1000000004 : Boolean;
+    BEGIN
+      Result := Regex.IsMatch4(Input, Pattern, Options);
+      TestToolkit.VerifyBooleanResult(TestToolkit.ArgsToString3('Input', Input, 'Options', Options.ToString(), 'Pattern', Pattern), Result, ExpectedResult);
+    END;
+
+    [Test]
+    PROCEDURE TestMatch@1000000009();
+    VAR
+      Pattern@1000000000 : Text;
+    BEGIN
+      Pattern := '[A-Z0-9]\d{2}[A-Z0-9](-\d{3}){2}[A-Z0-9]';
+      TestMatchOnce('Part No.: 1298-673-4192, On Stock: TRUE', Pattern, TRUE, 10, '1298-673-4192');
+      TestMatchOnce('Number: A08Z-931-468A', Pattern, TRUE, 8, 'A08Z-931-468A');
+      TestMatchOnce('Article _A90-123-129X', Pattern, FALSE, 0, '');
+      TestMatchOnce('12345-KKA-1230 in Warehouse', Pattern, FALSE, 0, '');
+      TestMatchOnce('0919-2893-1256', Pattern, FALSE, 0, '');
+    END;
+    LOCAL PROCEDURE TestMatchOnce@1000000010(Input@1000000002 : Text;Pattern@1000000003 : Text;ExpectedSuccess@1000000005 : Boolean;ExpectedIndex@1000000007 : Integer;ExpectedValue@1000000004 : Text);
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Match@1000000000 : Codeunit 3052;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Match(Input, Match);
+      VerifyMatch(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Match, ExpectedSuccess, ExpectedIndex, ExpectedValue);
+    END;
+
+    [Test]
+    PROCEDURE TestMatch2@1000000036();
+    VAR
+      Pattern@1000000000 : Text;
+    BEGIN
+      Pattern := '(Code|Text)\[\d+\]';
+      TestMatch2Once('Create Code[20] or Text[20] variable and initialise.', 10, Pattern, TRUE, 19, 'Text[20]');
+      TestMatch2Once('Make it Code[1024] or Text[MAX].', 15, Pattern, FALSE, 0, '');
+      TestMatch2Once('In classic you can declare Text[1024].', 20, Pattern, TRUE, 27, 'Text[1024]');
+    END;
+    LOCAL PROCEDURE TestMatch2Once@1000000037(Input@1000000001 : Text;StartAt@1000000003 : Integer;Pattern@1000000007 : Text;ExpectedSuccess@1000000005 : Boolean;ExpectedIndex@1000000008 : Integer;ExpectedValue@1000000009 : Text);
+    VAR
+      Regex@1000000000 : Codeunit 3001;
+      Match@1000000004 : Codeunit 3052;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Match2(Input, StartAt, Match);
+      VerifyMatch(TestToolkit.ArgsToString3('Input', Input, 'StartAt', StartAt, 'Pattern', Pattern), Match, ExpectedSuccess, ExpectedIndex, ExpectedValue);
+    END;
+
+    [Test]
+    PROCEDURE TestMatch3@1000000043();
+    VAR
+      Pattern@1000000000 : Text;
+    BEGIN
+      Pattern := '(Code|Text)\[\d+\]';
+      TestMatch3Once('Create Code[20] or Text[20] variable and initialise.', Pattern, 10, 30, TRUE, 19, 'Text[20]');
+      TestMatch3Once('Create Code[20] or Text[20] variable and initialise.', Pattern, 10, 15, FALSE, 0, '');
+    END;
+    LOCAL PROCEDURE TestMatch3Once@1000000042(Input@1000000001 : Text;Pattern@1000000007 : Text;Beginning@1000000003 : Integer;Length@1000000012 : Integer;ExpectedSuccess@1000000005 : Boolean;ExpectedIndex@1000000008 : Integer;ExpectedValue@1000000009 : Text);
+    VAR
+      Regex@1000000000 : Codeunit 3001;
+      Match@1000000004 : Codeunit 3052;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Match3(Input, Beginning, Length, Match);
+      VerifyMatch(TestToolkit.ArgsToString4('Input', Input, 'Beginning', Beginning, 'Length', Length, 'Pattern', Pattern), Match, ExpectedSuccess, ExpectedIndex, ExpectedValue);
+    END;
+
+    [Test]
+    PROCEDURE TestMatch4@1000000052();
+    VAR
+      Pattern@1000000000 : Text;
+    BEGIN
+      Pattern := '[A-Z0-9]\d{2}[A-Z0-9](-\d{3}){2}[A-Z0-9]';
+      TestMatch4Once('Part No.: 1298-673-4192, On Stock: TRUE', Pattern, TRUE, 10, '1298-673-4192');
+      TestMatch4Once('Number: A08Z-931-468A', Pattern, TRUE, 8, 'A08Z-931-468A');
+      TestMatch4Once('Article _A90-123-129X', Pattern, FALSE, 0, '');
+      TestMatch4Once('12345-KKA-1230 in Warehouse', Pattern, FALSE, 0, '');
+      TestMatch4Once('0919-2893-1256', Pattern, FALSE, 0, '');
+    END;
+    LOCAL PROCEDURE TestMatch4Once@1000000053(Input@1000000000 : Text;Pattern@1000000001 : Text;ExpectedSuccess@1000000006 : Boolean;ExpectedIndex@1000000005 : Integer;ExpectedValue@1000000004 : Text);
+    VAR
+      Regex@1000000002 : Codeunit 3001;
+      Match@1000000003 : Codeunit 3052;
+    BEGIN
+      Regex.Match4(Input, Pattern, Match);
+      VerifyMatch(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Match, ExpectedSuccess, ExpectedIndex, ExpectedValue);
+    END;
+
+    [Test]
+    PROCEDURE TestMatch5@1000000059();
+    VAR
+      Pattern@1000000000 : Text;
+      Options@1000000001 : Codeunit 3051;
+    BEGIN
+      Pattern := '[A-Z0-9]\d{2}[A-Z0-9](-\d{3}){2}[A-Z0-9]';
+      Options.IgnoreCase();
+      TestMatch5Once('Part No.: 1298-673-4192, On Stock: TRUE', Options, Pattern, TRUE, 10, '1298-673-4192');
+      TestMatch5Once('Number: a08Z-931-468a', Options, Pattern, TRUE, 8, 'a08Z-931-468a');
+      TestMatch5Once('Article _A90-123-129X', Options, Pattern, FALSE, 0, '');
+      TestMatch5Once('12345-KKa-1230 in Warehouse', Options, Pattern, FALSE, 0, '');
+      TestMatch5Once('0919-2893-1256', Options, Pattern, FALSE, 0, '');
+    END;
+    LOCAL PROCEDURE TestMatch5Once@1000000058(Input@1000000000 : Text;VAR Options@1000000007 : Codeunit 3051;Pattern@1000000001 : Text;ExpectedSuccess@1000000006 : Boolean;ExpectedIndex@1000000005 : Integer;ExpectedValue@1000000004 : Text);
+    VAR
+      Regex@1000000002 : Codeunit 3001;
+      Match@1000000003 : Codeunit 3052;
+    BEGIN
+      Regex.Match5(Input, Pattern, Options, Match);
+      VerifyMatch(TestToolkit.ArgsToString3('Input', Input, 'Options', Options.ToString(), 'Pattern', Pattern), Match, ExpectedSuccess, ExpectedIndex, ExpectedValue);
+    END;
+
+    [Test]
+    PROCEDURE TestMatches@1000000063();
+    VAR
+      Pattern@1000000000 : Text;
+      ExpectedIndexes@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+      ExpectedValues@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+    BEGIN
+      Pattern := '[A-Z0-9]\d{2}[A-Z0-9](-\d{3}){2}[A-Z0-9]';
+
+      TestToolkit.SetArray3(ExpectedIndexes, 11, 26, 44);
+      TestToolkit.SetArray3(ExpectedValues, '1298-673-4192', '1321-675-8745', 'A234-342-834Z');
+      TestMatchesOnce('Part Nos.: 1298-673-4192, 1321-675-8745 and A234-342-834Z', Pattern, 3, ExpectedIndexes, ExpectedValues);
+
+      TestToolkit.SetArray1(ExpectedIndexes, 25);
+      TestToolkit.SetArray1(ExpectedValues, 'Z093-902-234B');
+      TestMatchesOnce('a08Z-931-468a = On Hold, Z093-902-234B = Active', Pattern, 1, ExpectedIndexes, ExpectedValues);
+
+      TestToolkit.SetArray2(ExpectedIndexes, 28, 58);
+      TestToolkit.SetArray2(ExpectedValues, 'A08Z-931-468A', 'K892-222-893L');
+      TestMatchesOnce('Alternatives _A90-123-129X, A08Z-931-468A, A034-KKK-468D, K892-222-893L', Pattern, 2, ExpectedIndexes, ExpectedValues);
+    END;
+    LOCAL PROCEDURE TestMatchesOnce@1000000064(Input@1000000002 : Text;Pattern@1000000003 : Text;ExpectedMatchesCount@1000000004 : Integer;ExpectedIndexes@1000000006 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";ExpectedValues@1000000005 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Regex@1000000000 : Codeunit 3001;
+      Matches@1000000001 : Codeunit 3053;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Matches(Input, Matches);
+      VerifyMatches(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Matches, ExpectedMatchesCount, ExpectedIndexes, ExpectedValues);
+    END;
+
+    [Test]
+    PROCEDURE TestMatches2@1000000022();
+    VAR
+      Pattern@1000000000 : Text;
+      ExpectedIndexes@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+      ExpectedValues@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+    BEGIN
+      Pattern := '[A-Z0-9]\d{2}[A-Z0-9](-\d{3}){2}[A-Z0-9]';
+
+      TestToolkit.SetArray2(ExpectedIndexes, 15, 30);
+      TestToolkit.SetArray2(ExpectedValues, '1321-675-8745', 'A234-342-834Z');
+      TestMatches2Once('1298-673-4192, 1321-675-8745, A234-342-834Z', 10, Pattern, 2, ExpectedIndexes, ExpectedValues);
+
+      TestToolkit.SetArray1(ExpectedIndexes, 30);
+      TestToolkit.SetArray1(ExpectedValues, 'Z093-902-234B');
+      TestMatches2Once('B111-223-023S, a08Z-931-468a, Z093-902-234B, M123-A1A-902N', 4, Pattern, 1, ExpectedIndexes, ExpectedValues);
+    END;
+    LOCAL PROCEDURE TestMatches2Once@1000000023(Input@1000000001 : Text;StartAt@1000000004 : Integer;Pattern@1000000000 : Text;ExpectedMatchesCount@1000000007 : Integer;ExpectedIndexes@1000000006 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";ExpectedValues@1000000005 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Regex@1000000003 : Codeunit 3001;
+      Matches@1000000002 : Codeunit 3053;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Matches2(Input, StartAt, Matches);
+      VerifyMatches(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Matches, ExpectedMatchesCount, ExpectedIndexes, ExpectedValues);
+    END;
+
+    [Test]
+    PROCEDURE TestMatches3@1000000033();
+    VAR
+      Pattern@1000000000 : Text;
+      ExpectedIndexes@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+      ExpectedValues@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+    BEGIN
+      Pattern := '[A-Z0-9]\d{2}[A-Z0-9](-\d{3}){2}[A-Z0-9]';
+
+      TestToolkit.SetArray3(ExpectedIndexes, 11, 26, 44);
+      TestToolkit.SetArray3(ExpectedValues, '1298-673-4192', '1321-675-8745', 'A234-342-834Z');
+      TestMatches3Once('Part Nos.: 1298-673-4192, 1321-675-8745 and A234-342-834Z', Pattern, 3, ExpectedIndexes, ExpectedValues);
+
+      TestToolkit.SetArray1(ExpectedIndexes, 25);
+      TestToolkit.SetArray1(ExpectedValues, 'Z093-902-234B');
+      TestMatches3Once('a08Z-931-468a = On Hold, Z093-902-234B = Active', Pattern, 1, ExpectedIndexes, ExpectedValues);
+
+      TestToolkit.SetArray2(ExpectedIndexes, 28, 58);
+      TestToolkit.SetArray2(ExpectedValues, 'A08Z-931-468A', 'K892-222-893L');
+      TestMatches3Once('Alternatives _A90-123-129X, A08Z-931-468A, A034-KKK-468D, K892-222-893L', Pattern, 2, ExpectedIndexes, ExpectedValues);
+    END;
+    LOCAL PROCEDURE TestMatches3Once@1000000029(Input@1000000002 : Text;Pattern@1000000003 : Text;ExpectedMatchesCount@1000000004 : Integer;ExpectedIndexes@1000000006 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";ExpectedValues@1000000005 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Regex@1000000000 : Codeunit 3001;
+      Matches@1000000001 : Codeunit 3053;
+    BEGIN
+      Regex.Matches3(Input, Pattern, Matches);
+      VerifyMatches(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Matches, ExpectedMatchesCount, ExpectedIndexes, ExpectedValues);
+    END;
+
+    [Test]
+    PROCEDURE TestMatches4@1000000034();
+    VAR
+      Pattern@1000000000 : Text;
+      Options@1000000003 : Codeunit 3051;
+      ExpectedIndexes@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+      ExpectedValues@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+    BEGIN
+      Pattern := '[A-Z0-9]\d{2}[A-Z0-9](-\d{3}){2}[A-Z0-9]';
+      Options.IgnoreCase();
+
+      TestToolkit.SetArray3(ExpectedIndexes, 11, 26, 44);
+      TestToolkit.SetArray3(ExpectedValues, '1298-673-4192', '1321-675-8745', 'a234-342-834z');
+      TestMatches4Once('Part Nos.: 1298-673-4192, 1321-675-8745 and a234-342-834z', Pattern, Options, 3, ExpectedIndexes, ExpectedValues);
+
+      TestToolkit.SetArray2(ExpectedIndexes, 0, 25);
+      TestToolkit.SetArray2(ExpectedValues, 'a08Z-931-468a', 'Z093-902-234b');
+      TestMatches4Once('a08Z-931-468a = On Hold, Z093-902-234b = Active', Pattern, Options, 2, ExpectedIndexes, ExpectedValues);
+
+      TestToolkit.SetArray2(ExpectedIndexes, 28, 58);
+      TestToolkit.SetArray2(ExpectedValues, 'A08Z-931-468a', 'k892-222-893L');
+      TestMatches4Once('Alternatives _A90-123-129X, A08Z-931-468a, A034-KKK-468D, k892-222-893L', Pattern, Options, 2, ExpectedIndexes, ExpectedValues);
+    END;
+    LOCAL PROCEDURE TestMatches4Once@1000000031(Input@1000000002 : Text;Pattern@1000000003 : Text;VAR Options@1000000007 : Codeunit 3051;ExpectedMatchesCount@1000000004 : Integer;ExpectedIndexes@1000000006 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";ExpectedValues@1000000005 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Regex@1000000000 : Codeunit 3001;
+      Matches@1000000001 : Codeunit 3053;
+    BEGIN
+      Regex.Matches4(Input, Pattern, Options, Matches);
+      VerifyMatches(TestToolkit.ArgsToString3('Input', Input, 'Options', Options.ToString(), 'Pattern', Pattern), Matches, ExpectedMatchesCount, ExpectedIndexes, ExpectedValues);
+    END;
+
+    [Test]
+    PROCEDURE TestReplace@1000000001();
+    VAR
+      Pattern@1000000000 : Text;
+      Replacement@1000000001 : Text;
+    BEGIN
+      Pattern := '([A-Z0-9]\d{2}[A-Z0-9])-(\d{3})-(\d{3}[A-Z0-9])';
+      Replacement := 'C=$1;P=$3;V=$2';
+      TestReplaceOnce('1298-673-4192', Pattern, Replacement, 'C=1298;P=4192;V=673');
+      TestReplaceOnce('A08Z-931-468A', Pattern, Replacement, 'C=A08Z;P=468A;V=931');
+      TestReplaceOnce('_A90-123-129X', Pattern, Replacement, '_A90-123-129X');
+      TestReplaceOnce('12345-KKA-1230', Pattern, Replacement, '12345-KKA-1230');
+    END;
+    LOCAL PROCEDURE TestReplaceOnce@1000000026(Input@1000000000 : Text;Pattern@1000000001 : Text;Replacement@1000000003 : Text;ExpectedReplacedText@1000000005 : Text);
+    VAR
+      Regex@1000000002 : Codeunit 3001;
+      ReplacedText@1000000004 : Text;
+    BEGIN
+      Regex.Regex(Pattern);
+      ReplacedText := Regex.Replace(Input, Replacement);
+      VerifyReplacedText(TestToolkit.ArgsToString3('Input', Input, 'Pattern', Pattern, 'Replacement', Replacement), ReplacedText, ExpectedReplacedText);
+    END;
+
+    [Test]
+    PROCEDURE TestReplace2@1000000007();
+    VAR
+      Pattern@1000000000 : Text;
+      Replacement@1000000001 : Text;
+    BEGIN
+      Pattern := '([A-Z0-9]\d{2}[A-Z0-9])-(\d{3})-(\d{3}[A-Z0-9])';
+      Replacement := 'C=$1;P=$3;V=$2';
+      TestReplace2Once('1298-673-4192, A08Z-931-468A', Pattern, Replacement, 2, 'C=1298;P=4192;V=673, C=A08Z;P=468A;V=931');
+      TestReplace2Once('1298-673-4192, A08Z-931-468A', Pattern, Replacement, 1, 'C=1298;P=4192;V=673, A08Z-931-468A');
+      TestReplace2Once('12345-KKA-1230, B00B-094-190M', Pattern, Replacement, 1, '12345-KKA-1230, C=B00B;P=190M;V=094');
+    END;
+    LOCAL PROCEDURE TestReplace2Once@1000000032(Input@1000000003 : Text;Pattern@1000000002 : Text;Replacement@1000000001 : Text;Count@1000000004 : Integer;ExpectedReplacedText@1000000000 : Text);
+    VAR
+      Regex@1000000006 : Codeunit 3001;
+      ReplacedText@1000000005 : Text;
+    BEGIN
+      Regex.Regex(Pattern);
+      ReplacedText := Regex.Replace2(Input, Replacement, Count);
+      VerifyReplacedText(TestToolkit.ArgsToString4('Input', Input, 'Pattern', Pattern, 'Replacement', Replacement, 'Count', Count), ReplacedText, ExpectedReplacedText);
+    END;
+
+    [Test]
+    PROCEDURE TestReplace3@1000000014();
+    VAR
+      Pattern@1000000001 : Text;
+      Replacement@1000000000 : Text;
+    BEGIN
+      Pattern := '([A-Z0-9]\d{2}[A-Z0-9])-(\d{3})-(\d{3}[A-Z0-9])';
+      Replacement := 'C=$1;P=$3;V=$2';
+      TestReplace3Once('1298-673-4192, A08Z-931-468A', Pattern, Replacement, 2, 10, '1298-673-4192, C=A08Z;P=468A;V=931');
+      TestReplace3Once('1298-673-4192, A08Z-931-468A, J90D-032-J90F', Pattern, Replacement, 1, 10, '1298-673-4192, C=A08Z;P=468A;V=931, J90D-032-J90F');
+    END;
+    LOCAL PROCEDURE TestReplace3Once@1000000030(Input@1000000006 : Text;Pattern@1000000005 : Text;Replacement@1000000004 : Text;Count@1000000003 : Integer;StartAt@1000000007 : Integer;ExpectedReplacedText@1000000002 : Text);
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      ReplacedText@1000000000 : Text;
+    BEGIN
+      Regex.Regex(Pattern);
+      ReplacedText := Regex.Replace3(Input, Replacement, Count, StartAt);
+      VerifyReplacedText(TestToolkit.ArgsToString5('Input', Input, 'Pattern', Pattern, 'Replacement', Replacement, 'Count', Count, 'StartAt', StartAt), ReplacedText, ExpectedReplacedText);
+    END;
+
+    [Test]
+    PROCEDURE TestReplace4@1000000015();
+    VAR
+      Pattern@1000000001 : Text;
+      Replacement@1000000000 : Text;
+    BEGIN
+      Pattern := '([A-Z0-9]\d{2}[A-Z0-9])-(\d{3})-(\d{3}[A-Z0-9])';
+      Replacement := 'C=$1;P=$3;V=$2';
+      TestReplace4Once('1298-673-4192', Pattern, Replacement, 'C=1298;P=4192;V=673');
+      TestReplace4Once('A08Z-931-468A', Pattern, Replacement, 'C=A08Z;P=468A;V=931');
+      TestReplace4Once('_A90-123-129X', Pattern, Replacement, '_A90-123-129X');
+      TestReplace4Once('12345-KKA-1230', Pattern, Replacement, '12345-KKA-1230');
+    END;
+    LOCAL PROCEDURE TestReplace4Once@1000000028(Input@1000000003 : Text;Pattern@1000000002 : Text;Replacement@1000000001 : Text;ExpectedReplacedText@1000000000 : Text);
+    VAR
+      Regex@1000000005 : Codeunit 3001;
+      ReplacedText@1000000004 : Text;
+    BEGIN
+      ReplacedText := Regex.Replace4(Input, Pattern, Replacement);
+      VerifyReplacedText(TestToolkit.ArgsToString3('Input', Input, 'Pattern', Pattern, 'Replacement', Replacement), ReplacedText, ExpectedReplacedText);
+    END;
+
+    [Test]
+    PROCEDURE TestReplace5@1000000016();
+    VAR
+      Pattern@1000000001 : Text;
+      Replacement@1000000000 : Text;
+      Options@1000000002 : Codeunit 3051;
+    BEGIN
+      Pattern := '([A-Z0-9]\d{2}[A-Z0-9])-(\d{3})-(\d{3}[A-Z0-9])';
+      Replacement := 'C=$1;P=$3;V=$2';
+      Options.IgnoreCase();
+      TestReplace5Once('1298-673-4192', Pattern, Replacement, Options, 'C=1298;P=4192;V=673');
+      TestReplace5Once('a08Z-931-468a', Pattern, Replacement, Options, 'C=a08Z;P=468a;V=931');
+      TestReplace5Once('_A90-123-129X', Pattern, Replacement, Options, '_A90-123-129X');
+      TestReplace5Once('12345-KKA-1230', Pattern, Replacement, Options, '12345-KKA-1230');
+    END;
+    LOCAL PROCEDURE TestReplace5Once@1000000027(Input@1000000003 : Text;Pattern@1000000002 : Text;Replacement@1000000001 : Text;VAR Options@1000000004 : Codeunit 3051;ExpectedReplacedText@1000000000 : Text);
+    VAR
+      Regex@1000000006 : Codeunit 3001;
+      ReplacedText@1000000005 : Text;
+    BEGIN
+      ReplacedText := Regex.Replace5(Input, Pattern, Replacement, Options);
+      VerifyReplacedText(TestToolkit.ArgsToString4('Input', Input, 'Pattern', Pattern, 'Replacement', Replacement, 'Options', Options.ToString()), ReplacedText, ExpectedReplacedText);
+    END;
+
+    [Test]
+    PROCEDURE TestSplit@1000000021();
+    VAR
+      Pattern@1000000000 : Text;
+      ExpectedStrings@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+    BEGIN
+      Pattern := '\w+=|,\w+=';
+      TestToolkit.SetArray4(ExpectedStrings, '', '123', 'One Two Three', 'true');
+      TestSplitOnce('Id=123,Name=One Two Three,Enabled=true', Pattern, ExpectedStrings);
+      TestToolkit.SetArray5(ExpectedStrings, '', 'Check Item Quality', 'John Smith', 'Daily', '12:00:00');
+      TestSplitOnce('Process=Check Item Quality,Responsible=John Smith,Frequency=Daily,Time=12:00:00', Pattern, ExpectedStrings);
+    END;
+    LOCAL PROCEDURE TestSplitOnce@1000000041(Input@1000000003 : Text;Pattern@1000000002 : Text;ExpectedStrings@1000000005 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Strings@1000000000 : Codeunit 3000;
+    BEGIN
+      Regex.Split(Input, Pattern, Strings);
+      VerifyStrings(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Strings, ExpectedStrings);
+    END;
+
+    [Test]
+    PROCEDURE TestSplit2@1000000017();
+    VAR
+      Pattern@1000000000 : Text;
+      ExpectedStrings@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+    BEGIN
+      Pattern := '\w+=|,\w+=';
+      TestToolkit.SetArray4(ExpectedStrings, '', 'one.jpg', 'two.jpg', 'three.jpg');
+      TestSplit2Once('File=one.jpg,File=two.jpg,File=three.jpg', Pattern, ExpectedStrings);
+      TestToolkit.SetArray4(ExpectedStrings, '', '123', 'One Two Three', 'true');
+      TestSplit2Once('Id=123,Name=One Two Three,Enabled=true', Pattern, ExpectedStrings);
+    END;
+    LOCAL PROCEDURE TestSplit2Once@1000000038(Input@1000000001 : Text;Pattern@1000000003 : Text;ExpectedStrings@1000000005 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Regex@1000000000 : Codeunit 3001;
+      Strings@1000000002 : Codeunit 3000;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Split2(Input, Strings);
+      VerifyStrings(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Strings, ExpectedStrings);
+    END;
+
+    [Test]
+    PROCEDURE TestSplit3@1000000018();
+    VAR
+      Pattern@1000000000 : Text;
+      ExpectedStrings@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+    BEGIN
+      Pattern := '\w+=|,\w+=';
+      TestToolkit.SetArray3(ExpectedStrings, '', '123', 'Active=false,Enabled=true');
+      TestSplit3Once('Id=123,Name=Active=false,Enabled=true', Pattern, 3, ExpectedStrings);
+      TestToolkit.SetArray3(ExpectedStrings, '', 'Check Item Quality', 'Name=John Smith,Frequency=Daily,Time=12:00:00');
+      TestSplit3Once('Process=Check Item Quality,Details=Name=John Smith,Frequency=Daily,Time=12:00:00', Pattern, 3, ExpectedStrings);
+    END;
+    LOCAL PROCEDURE TestSplit3Once@1000000039(Input@1000000002 : Text;Pattern@1000000001 : Text;Count@1000000003 : Integer;ExpectedStrings@1000000006 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Regex@1000000005 : Codeunit 3001;
+      Strings@1000000004 : Codeunit 3000;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Split3(Input, Count, Strings);
+      VerifyStrings(TestToolkit.ArgsToString3('Input', Input, 'Pattern', Pattern, 'Count', Count), Strings, ExpectedStrings);
+    END;
+
+    [Test]
+    PROCEDURE TestSplit4@1000000019();
+    VAR
+      Pattern@1000000000 : Text;
+      ExpectedStrings@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+    BEGIN
+      Pattern := '\w+=|,\w+=';
+      TestToolkit.SetArray2(ExpectedStrings, 'Id=123,Nam', 'One Two Three,Enabled=true');
+      TestSplit4Once('Id=123,Name=One Two Three,Enabled=true', Pattern, 2, 10, ExpectedStrings);
+      TestToolkit.SetArray2(ExpectedStrings, 'Process=Check Item Quality', 'Name=John Smith,Frequency=Daily,Time=12:00:00');
+      TestSplit4Once('Process=Check Item Quality,Details=Name=John Smith,Frequency=Daily,Time=12:00:00', Pattern, 2, 25, ExpectedStrings);
+    END;
+    LOCAL PROCEDURE TestSplit4Once@1000000040(Input@1000000003 : Text;Pattern@1000000002 : Text;Count@1000000001 : Integer;StartAt@1000000004 : Integer;ExpectedStrings@1000000007 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Regex@1000000006 : Codeunit 3001;
+      Strings@1000000005 : Codeunit 3000;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Split4(Input, Count, StartAt, Strings);
+      VerifyStrings(TestToolkit.ArgsToString4('Input', Input, 'Pattern', Pattern, 'Count', Count, 'StartAt', StartAt), Strings, ExpectedStrings);
+    END;
+
+    [Test]
+    PROCEDURE TestSplit5@1000000024();
+    VAR
+      Pattern@1000000000 : Text;
+      Options@1000000002 : Codeunit 3051;
+      ExpectedStrings@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+    BEGIN
+      Pattern := '[A-Z]+=|,[A-Z]+=';
+      Options.IgnoreCase();
+      TestToolkit.SetArray4(ExpectedStrings, '', '123', 'One Two Three', 'true');
+      TestSplit5Once('Id=123,Name=One Two Three,Enabled=true', Pattern, Options, ExpectedStrings);
+      TestToolkit.SetArray5(ExpectedStrings, '', 'Check Item Quality', 'John Smith', 'Daily', '12:00:00');
+      TestSplit5Once('Process=Check Item Quality,Responsible=John Smith,Frequency=Daily,Time=12:00:00', Pattern, Options, ExpectedStrings);
+    END;
+    LOCAL PROCEDURE TestSplit5Once@1000000044(Input@1000000003 : Text;Pattern@1000000002 : Text;VAR Options@1000000004 : Codeunit 3051;ExpectedStrings@1000000006 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Strings@1000000000 : Codeunit 3000;
+    BEGIN
+      Regex.Split5(Input, Pattern, Options, Strings);
+      VerifyStrings(TestToolkit.ArgsToString3('Input', Input, 'Pattern', Pattern, 'Options', Options.ToString()), Strings, ExpectedStrings);
+    END;
+    LOCAL PROCEDURE VerifyMatch@1000000013(Arguments@1000000001 : Text;VAR Match@1000000002 : Codeunit 3052;ExpectedSuccess@1000000003 : Boolean;ExpectedIndex@1000000004 : Integer;ExpectedValue@1000000005 : Text);
+    BEGIN
+      TestToolkit.VerifyBooleanResult(Arguments, Match.Success, ExpectedSuccess);
+      TestToolkit.VerifyIntegerResult(Arguments, Match.Index, ExpectedIndex);
+      TestToolkit.VerifyTextResult(Arguments, Match.Value, ExpectedValue);
+    END;
+    LOCAL PROCEDURE VerifyMatches@1000000008(Arguments@1000000004 : Text;VAR Matches@1000000005 : Codeunit 3053;ExpectedMatchesCount@1000000002 : Integer;ExpectedIndexes@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";ExpectedValues@1000000000 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Index@1000000006 : Integer;
+      Match@1000000007 : Codeunit 3052;
+    BEGIN
+      TestToolkit.VerifyIntegerResult(Arguments, Matches.Count, ExpectedMatchesCount);
+      FOR Index := 0 TO Matches.Count - 1 DO BEGIN
+        Matches.Item(Index, Match);
+        TestToolkit.VerifyIntegerResult(Arguments, Match.Index, ExpectedIndexes.Item(Index));
+        TestToolkit.VerifyTextResult(Arguments, Match.Value, ExpectedValues.Item(Index));
+      END;
+    END;
+    LOCAL PROCEDURE VerifyReplacedText@1000000050(Arguments@1000000003 : Text;ReplacedText@1000000001 : Text;ExpectedReplacedText@1000000000 : Text);
+    BEGIN
+      TestToolkit.VerifyTextResult(Arguments, ReplacedText, ExpectedReplacedText);
+    END;
+    LOCAL PROCEDURE VerifyStrings@1000000047(Arguments@1000000003 : Text;VAR Strings@1000000001 : Codeunit 3000;ExpectedStrings@1000000004 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Equal@1000000000 : Boolean;
+      Index@1000000005 : Integer;
+      String@1000000008 : Text;
+      ExpectedString@1000000009 : Text;
+      StringsArray@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Array";
+    BEGIN
+      Equal := (Strings.Length = ExpectedStrings.Count);
+      IF (Equal) THEN BEGIN
+        FOR Index := 0 TO Strings.Length - 1 DO BEGIN
+          String := Strings.GetValueAsText(Index);
+          ExpectedString := ExpectedStrings.Item(Index);
+          Equal := ((Equal) AND (String = ExpectedString));
+          IF ( NOT (Equal)) THEN BEGIN
+            Index := Strings.Length;
+          END;
+        END;
+      END;
+      Strings.GetArray(StringsArray);
+      TestToolkit.VerifyResult(Arguments, Equal, STRSUBSTNO('[%1] %2', StringsArray.Length, TestToolkit.ArrayToString(StringsArray)),
+        STRSUBSTNO('[%1] %2', ExpectedStrings.Count, TestToolkit.ArrayListToString(ExpectedStrings)));
+    END;
+
+    [Test]
+    PROCEDURE TestRegexOptionsSingle@1000000045();
+    VAR
+      RegexOptions@1000000000 : Codeunit 3051;
+    BEGIN
+      CLEAR(RegexOptions);
+      RegexOptions.Compiled();
+      TestRegexOptionsOnce(RegexOptions, 8);
+
+      CLEAR(RegexOptions);
+      RegexOptions.CultureInvariant();
+      TestRegexOptionsOnce(RegexOptions, 512);
+
+      CLEAR(RegexOptions);
+      RegexOptions.ECMAScript();
+      TestRegexOptionsOnce(RegexOptions, 256);
+
+      CLEAR(RegexOptions);
+      RegexOptions.ExplicitCapture();
+      TestRegexOptionsOnce(RegexOptions, 4);
+
+      CLEAR(RegexOptions);
+      RegexOptions.IgnoreCase();
+      TestRegexOptionsOnce(RegexOptions, 1);
+
+      CLEAR(RegexOptions);
+      RegexOptions.IgnorePatternWhitespace();
+      TestRegexOptionsOnce(RegexOptions, 32);
+
+      CLEAR(RegexOptions);
+      RegexOptions.Multiline();
+      TestRegexOptionsOnce(RegexOptions, 2);
+
+      CLEAR(RegexOptions);
+      RegexOptions.None();
+      TestRegexOptionsOnce(RegexOptions, 0);
+
+      CLEAR(RegexOptions);
+      RegexOptions.RightToLeft();
+      TestRegexOptionsOnce(RegexOptions, 64);
+
+      CLEAR(RegexOptions);
+      RegexOptions.Singleline();
+      TestRegexOptionsOnce(RegexOptions, 16);
+    END;
+
+    [Test]
+    PROCEDURE TestRegexOptionsOr@1000000035();
+    VAR
+      RegexOptions@1000000000 : Codeunit 3051;
+      RegexOptionsString@1000000001 : Text;
+    BEGIN
+      CLEAR(RegexOptions);
+      RegexOptions.BitwiseOr(RegexOptions.IgnoreCase(), RegexOptions.Multiline());
+      TestRegexOptionsOnce(RegexOptions, 3);
+
+      CLEAR(RegexOptions);
+      RegexOptions.BitwiseOr(RegexOptions.BitwiseOr(RegexOptions.IgnoreCase(), RegexOptions.Multiline()), RegexOptions.ExplicitCapture());
+      TestRegexOptionsOnce(RegexOptions, 7);
+
+      RegexOptions.BitwiseOr(RegexOptions.BitwiseOr(RegexOptions.CultureInvariant(), RegexOptions.IgnorePatternWhitespace()),
+        RegexOptions.BitwiseOr(RegexOptions.Singleline(), RegexOptions.IgnoreCase()));
+      TestRegexOptionsOnce(RegexOptions, 561);
+    END;
+    LOCAL PROCEDURE TestRegexOptionsOnce@100000001(RegexOptions@100000000 : Codeunit 3051;ExpectedResult@100000001 : Integer);
+    BEGIN
+      TestToolkit.VerifyIntegerResult(RegexOptions.ToString(), RegexOptions.ToInteger(), ExpectedResult);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/Test/COD145902.TXT
+++ b/Test/COD145902.TXT
@@ -1,0 +1,308 @@
+OBJECT Codeunit 145902 Test_DotNet_MatchGroupCapture
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    Subtype=Test;
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      TestToolkit@1000000000 : Codeunit 145904;
+
+    [Test]
+    PROCEDURE TestMatchGroups@1000000000();
+    VAR
+      Pattern@1000000000 : Text;
+      ExpectedLengths@1000000003 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+      ExpectedNames@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+      ExpectedValues@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+    BEGIN
+      Pattern := '(?<Family>[A-Z]\d{2}[A-Z])-(?<Series>\d{3})-(?<Variant>[A-Z])';
+
+      TestToolkit.SetArray4(ExpectedLengths, 10, 4, 3, 1);
+      TestToolkit.SetArray4(ExpectedNames, '0', 'Family', 'Series', 'Variant');
+      TestToolkit.SetArray4(ExpectedValues, 'A23B-234-C', 'A23B', '234', 'C');
+      TestMatchGroupsOnce('Part No.: A23B-234-C, Replacement: C99Z-902-M', Pattern, 4, ExpectedLengths, ExpectedNames, ExpectedValues);
+
+      TestToolkit.SetArray4(ExpectedLengths, 10, 4, 3, 1);
+      TestToolkit.SetArray4(ExpectedNames, '0', 'Family', 'Series', 'Variant');
+      TestToolkit.SetArray4(ExpectedValues, 'C99Z-902-M', 'C99Z', '902', 'M');
+      TestMatchGroupsOnce('Part No.: 123B-234-C, Replacement: C99Z-902-M', Pattern, 4, ExpectedLengths, ExpectedNames, ExpectedValues);
+
+      TestToolkit.SetArray1(ExpectedLengths, 0);
+      TestToolkit.SetArray1(ExpectedNames, '0');
+      TestToolkit.SetArray1(ExpectedValues, '');
+      TestMatchGroupsOnce('Part No.: 123B-234-C, Replacement: C99Z-AA2-M', Pattern, 1, ExpectedLengths, ExpectedNames, ExpectedValues);
+    END;
+    LOCAL PROCEDURE TestMatchGroupsOnce@1000000003(Input@1000000003 : Text;Pattern@1000000002 : Text;ExpectedCount@1000000004 : Integer;ExpectedLengths@1000000009 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";ExpectedNames@1000000008 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";ExpectedValues@1000000010 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Match@1000000000 : Codeunit 3052;
+      Groups@1000000006 : Codeunit 3055;
+      Group@1000000005 : Codeunit 3054;
+      Index@1000000007 : Integer;
+      ExpectedLength@1000000011 : Integer;
+      ExpectedName@1000000012 : Text;
+      ExpectedValue@1000000013 : Text;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Match(Input, Match);
+      Match.Groups(Groups);
+      TestToolkit.VerifyIntegerResult(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Groups.Count, ExpectedCount);
+      FOR Index := 0 TO Groups.Count-1 DO BEGIN
+        ExpectedLength := ExpectedLengths.Item(Index);
+        ExpectedName := ExpectedNames.Item(Index);
+        ExpectedValue := ExpectedValues.Item(Index);
+        Groups.Item(Index, Group);
+        TestToolkit.VerifyIntegerResult(TestToolkit.ArgsToString4('Input', Input, 'Pattern', Pattern, 'GroupIndex', Index, 'Property', 'Length'), Group.Length, ExpectedLength);
+        TestToolkit.VerifyTextResult(TestToolkit.ArgsToString4('Input', Input, 'Pattern', Pattern, 'GroupIndex', Index, 'Property', 'Name'), Group.Name, ExpectedName);
+        TestToolkit.VerifyTextResult(TestToolkit.ArgsToString4('Input', Input, 'Pattern', Pattern, 'GroupIndex', Index, 'Property', 'Value'), Group.Value, ExpectedValue);
+      END;
+    END;
+
+    [Test]
+    PROCEDURE TestMatchIndex@1000000001();
+    VAR
+      Pattern@1000000000 : Text;
+    BEGIN
+      Pattern := '[A-Z]\d{2}[A-Z]-\d{3}-[A-Z]';
+      TestMatchIndexOnce('Part No.: A23B-234-C, Replacement: C99Z-902-M', Pattern, 10);
+      TestMatchIndexOnce('Part No.: 123B-234-C, Replacement: C99Z-902-M', Pattern, 35);
+      TestMatchIndexOnce('Part No.: 123B-234-C, Replacement: C99Z-AA2-M', Pattern, 0);
+    END;
+    LOCAL PROCEDURE TestMatchIndexOnce@1000000008(Input@1000000003 : Text;Pattern@1000000002 : Text;ExpectedIndex@1000000004 : Integer);
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Match@1000000000 : Codeunit 3052;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Match(Input, Match);
+      TestToolkit.VerifyIntegerResult(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Match.Index, ExpectedIndex);
+    END;
+
+    [Test]
+    PROCEDURE TestMatchLength@1000000002();
+    VAR
+      Pattern@1000000000 : Text;
+    BEGIN
+      Pattern := '[A-Z]\d{2}[A-Z]-\d{3}-[A-Z]';
+      TestMatchLengthOnce('Part No.: A23B-234-C, Replacement: C99Z-902-M', Pattern, 10);
+      TestMatchLengthOnce('Part No.: 123B-234-C, Replacement: C99Z-902-M', Pattern, 10);
+      TestMatchLengthOnce('Part No.: 123B-234-C, Replacement: C99Z-AA2-M', Pattern, 0);
+    END;
+    LOCAL PROCEDURE TestMatchLengthOnce@1000000007(Input@1000000003 : Text;Pattern@1000000002 : Text;ExpectedLength@1000000004 : Integer);
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Match@1000000000 : Codeunit 3052;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Match(Input, Match);
+      TestToolkit.VerifyIntegerResult(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Match.Length, ExpectedLength);
+    END;
+
+    [Test]
+    PROCEDURE TestMatchSuccess@1000000004();
+    VAR
+      Pattern@1000000000 : Text;
+    BEGIN
+      Pattern := '[A-Z]\d{2}[A-Z]-\d{3}-[A-Z]';
+      TestMatchSuccessOnce('Part No.: A23B-234-C, Replacement: C99Z-902-M', Pattern, TRUE);
+      TestMatchSuccessOnce('Part No.: 123B-234-C, Replacement: C99Z-902-M', Pattern, TRUE);
+      TestMatchSuccessOnce('Part No.: 123B-234-C, Replacement: C99Z-AA2-M', Pattern, FALSE);
+    END;
+    LOCAL PROCEDURE TestMatchSuccessOnce@1000000012(Input@1000000003 : Text;Pattern@1000000002 : Text;ExpectedSuccess@1000000004 : Boolean);
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Match@1000000000 : Codeunit 3052;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Match(Input, Match);
+      TestToolkit.VerifyBooleanResult(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Match.Success, ExpectedSuccess);
+    END;
+
+    [Test]
+    PROCEDURE TestMatchValue@1000000005();
+    VAR
+      Pattern@1000000000 : Text;
+    BEGIN
+      Pattern := '[A-Z]\d{2}[A-Z]-\d{3}-[A-Z]';
+      TestMatchValueOnce('Part No.: A23B-234-C, Replacement: C99Z-902-M', Pattern, 'A23B-234-C');
+      TestMatchValueOnce('Part No.: 123B-234-C, Replacement: C99Z-902-M', Pattern, 'C99Z-902-M');
+      TestMatchValueOnce('Part No.: 123B-234-C, Replacement: C99Z-AA2-M', Pattern, '');
+    END;
+    LOCAL PROCEDURE TestMatchValueOnce@1000000011(Input@1000000003 : Text;Pattern@1000000002 : Text;ExpectedValue@1000000004 : Text);
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Match@1000000000 : Codeunit 3052;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Match(Input, Match);
+      TestToolkit.VerifyTextResult(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Match.Value, ExpectedValue);
+    END;
+
+    [Test]
+    PROCEDURE TestMatchResult@1000000006();
+    VAR
+      Pattern@1000000000 : Text;
+      Replacement@1000000001 : Text;
+    BEGIN
+      Pattern := '([A-Z]\d{2}[A-Z])-(\d{3})-([A-Z])';
+      Replacement := 'Series: $2; Family: $1; Variant: $3';
+      TestMatchResultOnce('Part No.: A23B-234-C, Replacement: C99Z-902-M', Pattern, Replacement, 'Series: 234; Family: A23B; Variant: C');
+      TestMatchResultOnce('Part No.: 123B-234-C, Replacement: C99Z-902-M', Pattern, Replacement, 'Series: 902; Family: C99Z; Variant: M');
+    END;
+    LOCAL PROCEDURE TestMatchResultOnce@1000000009(Input@1000000003 : Text;Pattern@1000000002 : Text;Replacement@1000000005 : Text;ExpectedResult@1000000004 : Text);
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Match@1000000000 : Codeunit 3052;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Match(Input, Match);
+      TestToolkit.VerifyTextResult(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Match.Result(Replacement), ExpectedResult);
+    END;
+
+    [Test]
+    PROCEDURE TestMatchNextMatch@1000000014();
+    VAR
+      Pattern@1000000000 : Text;
+    BEGIN
+      Pattern := '[A-Z]\d{2}[A-Z]-\d{3}-[A-Z]';
+      TestMatchNextMatchOnce('Part No.: A23B-234-C, Replacement: C99Z-902-M', Pattern, 'A23B-234-C', 'C99Z-902-M');
+      TestMatchNextMatchOnce('Part No.: 123B-234-C, Replacement: C99Z-902-M', Pattern, 'C99Z-902-M', '');
+      TestMatchNextMatchOnce('Part No.: 123B-234-C, Replacement: C99Z-AA2-M', Pattern, '', '');
+    END;
+    LOCAL PROCEDURE TestMatchNextMatchOnce@1000000019(Input@1000000003 : Text;Pattern@1000000002 : Text;ExpectedValue@1000000000 : Text;ExpectedValue2@1000000006 : Text);
+    VAR
+      Regex@1000000004 : Codeunit 3001;
+      Match@1000000001 : Codeunit 3052;
+      Match2@1000000005 : Codeunit 3052;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Match(Input, Match);
+      Match.NextMatch(Match2);
+      TestToolkit.VerifyTextResult(TestToolkit.ArgsToString3('Input', Input, 'Pattern', Pattern, 'Property', 'Value'), Match.Value, ExpectedValue);
+      TestToolkit.VerifyTextResult(TestToolkit.ArgsToString3('Input', Input, 'Pattern', Pattern, 'Property', 'Value2'), Match2.Value, ExpectedValue2);
+    END;
+
+    [Test]
+    PROCEDURE TestMatchesCount@1000000016();
+    VAR
+      Pattern@1000000000 : Text;
+    BEGIN
+      Pattern := '[A-Z]\d{2}[A-Z]-\d{3}-[A-Z]';
+      TestMatchesCountOnce('Part No.: A23B-234-C, Replacement: C99Z-902-M', Pattern, 2);
+      TestMatchesCountOnce('Part No.: 123B-234-C, Replacement: C99Z-902-M', Pattern, 1);
+      TestMatchesCountOnce('Part No.: 123B-234-C, Replacement: C99Z-AA2-M', Pattern, 0);
+    END;
+    LOCAL PROCEDURE TestMatchesCountOnce@1000000015(Input@1000000003 : Text;Pattern@1000000002 : Text;ExpectedCount@1000000004 : Integer);
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Matches@1000000000 : Codeunit 3053;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Matches(Input, Matches);
+      TestToolkit.VerifyIntegerResult(TestToolkit.ArgsToString2('Input', Input, 'Pattern', Pattern), Matches.Count, ExpectedCount);
+    END;
+
+    [Test]
+    PROCEDURE TestMatchesItem@1000000013();
+    VAR
+      Pattern@1000000000 : Text;
+      ExpectedIndexes@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+      ExpectedValues@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+    BEGIN
+      Pattern := '[A-Z]\d{2}[A-Z]-\d{3}-[A-Z]';
+
+      TestToolkit.SetArray2(ExpectedIndexes, 10, 35);
+      TestToolkit.SetArray2(ExpectedValues, 'A23B-234-C', 'C99Z-902-M');
+      TestMatchesItemOnce('Part No.: A23B-234-C, Replacement: C99Z-902-M', Pattern, ExpectedIndexes, ExpectedValues);
+
+      TestToolkit.SetArray1(ExpectedIndexes, 35);
+      TestToolkit.SetArray1(ExpectedValues, 'C99Z-902-M');
+      TestMatchesItemOnce('Part No.: 123B-234-C, Replacement: C99Z-902-M', Pattern, ExpectedIndexes, ExpectedValues);
+    END;
+    LOCAL PROCEDURE TestMatchesItemOnce@1000000010(Input@1000000003 : Text;Pattern@1000000002 : Text;ExpectedIndexes@1000000005 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";ExpectedValues@1000000004 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Matches@1000000000 : Codeunit 3053;
+      Match@1000000006 : Codeunit 3052;
+      Index@1000000007 : Integer;
+      ExpectedIndex@1000000008 : Integer;
+      ExpectedValue@1000000009 : Text;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Matches(Input, Matches);
+      FOR Index := 0 TO Matches.Count - 1 DO BEGIN
+        ExpectedIndex := ExpectedIndexes.Item(Index);
+        ExpectedValue := ExpectedValues.Item(Index);
+        Matches.Item(Index, Match);
+        TestToolkit.VerifyIntegerResult(TestToolkit.ArgsToString4('Input', Input, 'Pattern', Pattern, 'Index', Index, 'Property', 'Index'), Match.Index, ExpectedIndex);
+        TestToolkit.VerifyTextResult(TestToolkit.ArgsToString4('Input', Input, 'Pattern', Pattern, 'Index', Index, 'Property', 'Value'), Match.Value, ExpectedValue);
+      END;
+    END;
+
+    [Test]
+    PROCEDURE TestGroupCaptures@1000000017();
+    VAR
+      Pattern@1000000000 : Text;
+      ExpectedIndexes@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+      ExpectedLengths@1000000003 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+      ExpectedValues@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+    BEGIN
+      Pattern := '\b(\w+\s*)+\.';
+
+      TestToolkit.SetArray5(ExpectedIndexes, 0, 4, 8, 14, 19);
+      TestToolkit.SetArray5(ExpectedLengths, 4, 4, 6, 5, 4);
+      TestToolkit.SetArray5(ExpectedValues, 'One ', 'Two ', 'Three ', 'Four ', 'Five');
+      TestGroupCapturesOnce('One Two Three Four Five.', Pattern, 5, ExpectedIndexes, ExpectedLengths, ExpectedValues);
+
+      TestToolkit.SetArray6(ExpectedIndexes, 0, 5, 8, 10, 19, 22);
+      TestToolkit.SetArray6(ExpectedLengths, 5, 3, 2, 9, 3, 7);
+      TestToolkit.SetArray6(ExpectedValues, 'This ', 'is ', 'a ', 'sentence ', 'in ', 'English');
+      TestGroupCapturesOnce('This is a sentence in English.', Pattern, 6, ExpectedIndexes, ExpectedLengths, ExpectedValues);
+    END;
+    LOCAL PROCEDURE TestGroupCapturesOnce@1000000018(Input@1000000001 : Text;Pattern@1000000000 : Text;ExpectedCount@1000000006 : Integer;ExpectedIndexes@1000000011 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";ExpectedLengths@1000000012 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";ExpectedValues@1000000010 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Regex@1000000005 : Codeunit 3001;
+      Match@1000000004 : Codeunit 3052;
+      Groups@1000000003 : Codeunit 3055;
+      Group@1000000002 : Codeunit 3054;
+      Captures@1000000007 : Codeunit 3057;
+      Capture@1000000008 : Codeunit 3056;
+      Index@1000000009 : Integer;
+      ExpectedIndex@1000000014 : Integer;
+      ExpectedLength@1000000015 : Integer;
+      ExpectedValue@1000000013 : Text;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Match(Input, Match);
+      Match.Groups(Groups);
+      TestToolkit.VerifyIntegerResult(TestToolkit.ArgsToString3('Input', Input, 'Pattern', Pattern, 'Property', 'No. of Groups'), Groups.Count, 2);
+      Groups.Item(1, Group);
+      Group.Captures(Captures);
+      TestToolkit.VerifyIntegerResult(TestToolkit.ArgsToString3('Input', Input, 'Pattern', Pattern, 'Property', 'No. of Captures'), Captures.Count, ExpectedCount);
+      FOR Index := 0 TO Captures.Count-1 DO BEGIN
+        ExpectedIndex := ExpectedIndexes.Item(Index);
+        ExpectedLength := ExpectedLengths.Item(Index);
+        ExpectedValue := ExpectedValues.Item(Index);
+        Captures.Item(Index, Capture);
+        TestToolkit.VerifyIntegerResult(TestToolkit.ArgsToString4('Input', Input, 'Pattern', Pattern, 'CaptureIndex', Index, 'Property', 'Index'), Capture.Index, ExpectedIndex);
+        TestToolkit.VerifyIntegerResult(TestToolkit.ArgsToString4('Input', Input, 'Pattern', Pattern, 'CaptureIndex', Index, 'Property', 'Length'), Capture.Length, ExpectedLength);
+        TestToolkit.VerifyTextResult(TestToolkit.ArgsToString4('Input', Input, 'Pattern', Pattern, 'CaptureIndex', Index, 'Property', 'Value'), Capture.Value, ExpectedValue);
+      END;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/Test/COD145903.TXT
+++ b/Test/COD145903.TXT
@@ -1,0 +1,87 @@
+OBJECT Codeunit 145903 Test_DotNet_Array
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    Subtype=Test;
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      TestToolkit@1000000000 : Codeunit 145904;
+
+    [Test]
+    PROCEDURE TestGetValueAsText@1000000000();
+    VAR
+      Pattern@1000000000 : Text;
+      ExpectedNames@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+    BEGIN
+      Pattern := '(?<Family>[A-Z]\d{2}[A-Z])-(?<Series>\d{3})-(?<Variant>[A-Z])';
+      TestToolkit.SetArray4(ExpectedNames, '0', 'Family', 'Series', 'Variant');
+      TestGetValueAsTextOnce('Part No.: A23B-234-C, Replacement: C99Z-902-M', Pattern, 4, ExpectedNames);
+      TestGetValueAsTextOnce('Part No.: 123B-234-C, Replacement: C99Z-902-M', Pattern, 4, ExpectedNames);
+    END;
+    LOCAL PROCEDURE TestGetValueAsTextOnce@1000000008(Input@1000000003 : Text;Pattern@1000000002 : Text;ExpectedLength@1000000004 : Integer;ExpectedNames@1000000006 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Match@1000000000 : Codeunit 3052;
+      GroupNames@1000000005 : Codeunit 3000;
+      GroupName@1000000008 : Text;
+      Index@1000000007 : Integer;
+      ExpectedName@1000000009 : Text;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Match(Input, Match);
+      Regex.GetGroupNames(GroupNames);
+      TestToolkit.VerifyIntegerResult(TestToolkit.ArgsToString3('Input', Input, 'Pattern', Pattern, 'Parameter', 'Length'), GroupNames.Length, ExpectedLength);
+      FOR Index := 0 TO GroupNames.Length - 1 DO BEGIN
+        ExpectedName := ExpectedNames.Item(Index);
+        GroupName := GroupNames.GetValueAsText(Index);
+        TestToolkit.VerifyTextResult(TestToolkit.ArgsToString4('Input', Input, 'Pattern', Pattern, 'Index', Index, 'Parameter', 'Name'), GroupName, ExpectedName);
+      END;
+    END;
+
+    [Test]
+    PROCEDURE TestGetValueAsInteger@1000000002();
+    VAR
+      Pattern@1000000000 : Text;
+      ExpectedNumbers@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";
+    BEGIN
+      Pattern := '(?<Family>[A-Z]\d{2}[A-Z])-(?<Series>\d{3})-(?<Variant>[A-Z])';
+      TestToolkit.SetArray4(ExpectedNumbers, 0, 1, 2, 3);
+      TestGetValueAsIntegerOnce('Part No.: A23B-234-C, Replacement: C99Z-902-M', Pattern, 4, ExpectedNumbers);
+      TestGetValueAsIntegerOnce('Part No.: 123B-234-C, Replacement: C99Z-902-M', Pattern, 4, ExpectedNumbers);
+    END;
+    LOCAL PROCEDURE TestGetValueAsIntegerOnce@1000000001(Input@1000000003 : Text;Pattern@1000000002 : Text;ExpectedLength@1000000004 : Integer;ExpectedNumbers@1000000006 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    VAR
+      Regex@1000000001 : Codeunit 3001;
+      Match@1000000000 : Codeunit 3052;
+      GroupNumbers@1000000005 : Codeunit 3000;
+      GroupNumber@1000000008 : Integer;
+      Index@1000000007 : Integer;
+      ExpectedNumber@1000000009 : Integer;
+    BEGIN
+      Regex.Regex(Pattern);
+      Regex.Match(Input, Match);
+      Regex.GetGroupNumbers(GroupNumbers);
+      TestToolkit.VerifyIntegerResult(TestToolkit.ArgsToString3('Input', Input, 'Pattern', Pattern, 'Parameter', 'Length'), GroupNumbers.Length, ExpectedLength);
+      FOR Index := 0 TO GroupNumbers.Length - 1 DO BEGIN
+        ExpectedNumber := ExpectedNumbers.Item(Index);
+        GroupNumber := GroupNumbers.GetValueAsInteger(Index);
+        TestToolkit.VerifyIntegerResult(TestToolkit.ArgsToString4('Input', Input, 'Pattern', Pattern, 'Index', Index, 'Parameter', 'Number'), GroupNumber, ExpectedNumber);
+      END;
+    END;
+
+    BEGIN
+    END.
+  }
+}
+

--- a/Test/COD145904.TXT
+++ b/Test/COD145904.TXT
@@ -1,0 +1,186 @@
+OBJECT Codeunit 145904 Test_DotNet_Regex_Toolkit
+{
+  OBJECT-PROPERTIES
+  {
+    Date=;
+    Time=;
+    Version List=;
+  }
+  PROPERTIES
+  {
+    OnRun=BEGIN
+          END;
+
+  }
+  CODE
+  {
+    VAR
+      TxtError@1000000000 : TextConst 'ENU=Arguments: %1\Result: %2\Expected: %3';
+    PROCEDURE VerifyBooleanResult@1000000020(Arguments@1000000003 : Text;Result@1000000001 : Boolean;ExpectedResult@1000000000 : Boolean);
+    BEGIN
+      VerifyResult(Arguments, Result = ExpectedResult, Result, ExpectedResult);
+    END;
+    PROCEDURE VerifyIntegerResult@1000000004(Arguments@1000000003 : Text;Result@1000000001 : Integer;ExpectedResult@1000000000 : Integer);
+    BEGIN
+      VerifyResult(Arguments, Result = ExpectedResult, Result, ExpectedResult);
+    END;
+    PROCEDURE VerifyTextResult@1000000006(Arguments@1000000003 : Text;Result@1000000001 : Text;ExpectedResult@1000000000 : Text);
+    BEGIN
+      VerifyResult(Arguments, Result = ExpectedResult, Result, ExpectedResult);
+    END;
+    PROCEDURE VerifyResult@1000000003(Arguments@1000000003 : Text;Verified@1000000001 : Boolean;Result@1000000000 : Variant;ExpectedResult@1000000004 : Variant);
+    BEGIN
+      IF ( NOT (Verified)) THEN
+        ERROR(TxtError, Arguments, Result, ExpectedResult);
+    END;
+    PROCEDURE ToString1@1000000007(Value1@1000000000 : Variant) : Text;
+    BEGIN
+      EXIT(STRSUBSTNO('%1', Value1));
+    END;
+    PROCEDURE ToString2@1000000012(Value1@1000000000 : Variant;Value2@1000000001 : Variant) : Text;
+    BEGIN
+      EXIT(STRSUBSTNO('%1, %2', Value1, Value2));
+    END;
+    PROCEDURE ToString3@1000000011(Value1@1000000000 : Variant;Value2@1000000001 : Variant;Value3@1000000005 : Variant) : Text;
+    BEGIN
+      EXIT(STRSUBSTNO('%1, %2, %3', Value1, Value2, Value3));
+    END;
+    PROCEDURE ToString4@1000000010(Value1@1000000000 : Variant;Value2@1000000001 : Variant;Value3@1000000005 : Variant;Value4@1000000004 : Variant) : Text;
+    BEGIN
+      EXIT(STRSUBSTNO('%1, %2, %3, %4', Value1, Value2, Value3, Value4));
+    END;
+    PROCEDURE ToString5@1000000009(Value1@1000000000 : Variant;Value2@1000000001 : Variant;Value3@1000000005 : Variant;Value4@1000000004 : Variant;Value5@1000000003 : Variant) : Text;
+    BEGIN
+      EXIT(STRSUBSTNO('%1, %2, %3, %4, %5', Value1, Value2, Value3, Value4, Value5));
+    END;
+    PROCEDURE ToString6@1000000018(Value1@1000000000 : Variant;Value2@1000000001 : Variant;Value3@1000000002 : Variant;Value4@1000000003 : Variant;Value5@1000000004 : Variant;Value6@1000000005 : Variant) : Text;
+    BEGIN
+      EXIT(STRSUBSTNO('%1, %2, %3, %4, %5, %6', Value1, Value2, Value3, Value4, Value5, Value6));
+    END;
+    PROCEDURE ArgsToString1@1000000021(Name1@1000000001 : Text;Value1@1000000000 : Variant) : Text;
+    BEGIN
+      EXIT(STRSUBSTNO('"%1"=%2', Name1, ToString(Value1)));
+    END;
+    PROCEDURE ArgsToString2@1000000022(Name1@1000000002 : Text;Value1@1000000000 : Variant;Name2@1000000003 : Text;Value2@1000000001 : Variant) : Text;
+    BEGIN
+      EXIT(STRSUBSTNO('"%1"=%2, "%3"=%4', Name1, ToString(Value1), Name2, ToString(Value2)));
+    END;
+    PROCEDURE ArgsToString3@1000000023(Name1@1000000003 : Text;Value1@1000000001 : Variant;Name2@1000000004 : Text;Value2@1000000000 : Variant;Name3@1000000005 : Text;Value3@1000000002 : Variant) : Text;
+    BEGIN
+      EXIT(STRSUBSTNO('"%1"=%2, "%3"=%4, "%5"=%6', Name1, ToString(Value1), Name2, ToString(Value2), Name3, ToString(Value3)));
+    END;
+    PROCEDURE ArgsToString4@1000000024(Name1@1000000004 : Text;Value1@1000000001 : Variant;Name2@1000000005 : Text;Value2@1000000000 : Variant;Name3@1000000006 : Text;Value3@1000000002 : Variant;Name4@1000000007 : Text;Value4@1000000003 : Variant) : Text;
+    BEGIN
+      EXIT(STRSUBSTNO('"%1"=%2, "%3"=%4, "%5"=%6, "%7"=%8', Name1, ToString(Value1), Name2, ToString(Value2), Name3, ToString(Value3), Name4, ToString(Value4)));
+    END;
+    PROCEDURE ArgsToString5@1000000001(Name1@1000000005 : Text;Value1@1000000001 : Variant;Name2@1000000006 : Text;Value2@1000000000 : Variant;Name3@1000000007 : Text;Value3@1000000002 : Variant;Name4@1000000008 : Text;Value4@1000000003 : Variant;Name5@1000000009 : Text;Value5@1000000004 : Variant) : Text;
+    BEGIN
+      EXIT(STRSUBSTNO('"%1"=%2, "%3"=%4, "%5"=%6, "%7"=%8, "%9"=%10', Name1, ToString(Value1), Name2, ToString(Value2), Name3, ToString(Value3), Name4, ToString(Value4), Name5, ToString(Value5)));
+    END;
+    PROCEDURE ArgsToString6@1000000014(Name1@1000000005 : Text;Value1@1000000001 : Variant;Name2@1000000006 : Text;Value2@1000000000 : Variant;Name3@1000000007 : Text;Value3@1000000002 : Variant;Name4@1000000008 : Text;Value4@1000000003 : Variant;Name5@1000000009 : Text;Value5@1000000004 : Variant;Name6@1000000011 : Text;Value6@1000000010 : Variant) : Text;
+    BEGIN
+      EXIT(STRSUBSTNO('"%1"=%2, "%3"=%4, "%5"=%6, "%7"=%8, "%9"=%10, "%11"=%12', Name1, ToString(Value1), Name2, ToString(Value2), Name3, ToString(Value3), Name4, ToString(Value4), Name5, ToString(Value5), Name6, ToString(Value6)));
+    END;
+    LOCAL PROCEDURE ToString@1000000005(Value@1000000000 : Variant) : Text;
+    BEGIN
+      EXIT(CONVERTSTR(FORMAT(Value), '\', '/'));
+    END;
+    PROCEDURE ClearArray@1000000025(VAR TheArray@1000000000 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList");
+    BEGIN
+      TheArray := TheArray.ArrayList();
+    END;
+    PROCEDURE SetArray1@1000000017(VAR TheArray@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";Value1@1000000000 : Variant);
+    BEGIN
+      TheArray := TheArray.ArrayList();
+      TheArray.Add(Value1);
+    END;
+    PROCEDURE SetArray2@1000000015(VAR TheArray@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";Value1@1000000000 : Variant;Value2@1000000001 : Variant);
+    BEGIN
+      TheArray := TheArray.ArrayList();
+      TheArray.Add(Value1);
+      TheArray.Add(Value2);
+    END;
+    PROCEDURE SetArray3@1000000016(VAR TheArray@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";Value1@1000000000 : Variant;Value2@1000000001 : Variant;Value3@1000000003 : Variant);
+    BEGIN
+      TheArray := TheArray.ArrayList();
+      TheArray.Add(Value1);
+      TheArray.Add(Value2);
+      TheArray.Add(Value3);
+    END;
+    PROCEDURE SetArray4@1000000000(VAR TheArray@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";Value1@1000000000 : Variant;Value2@1000000001 : Variant;Value3@1000000003 : Variant;Value4@1000000004 : Variant);
+    BEGIN
+      TheArray := TheArray.ArrayList();
+      TheArray.Add(Value1);
+      TheArray.Add(Value2);
+      TheArray.Add(Value3);
+      TheArray.Add(Value4);
+    END;
+    PROCEDURE SetArray5@1000000002(VAR TheArray@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";Value1@1000000000 : Variant;Value2@1000000001 : Variant;Value3@1000000003 : Variant;Value4@1000000004 : Variant;Value5@1000000005 : Variant);
+    BEGIN
+      TheArray := TheArray.ArrayList();
+      TheArray.Add(Value1);
+      TheArray.Add(Value2);
+      TheArray.Add(Value3);
+      TheArray.Add(Value4);
+      TheArray.Add(Value5);
+    END;
+    PROCEDURE SetArray6@1000000013(VAR TheArray@1000000002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList";Value1@1000000000 : Variant;Value2@1000000001 : Variant;Value3@1000000003 : Variant;Value4@1000000004 : Variant;Value5@1000000005 : Variant;Value6@1000000006 : Variant);
+    BEGIN
+      TheArray := TheArray.ArrayList();
+      TheArray.Add(Value1);
+      TheArray.Add(Value2);
+      TheArray.Add(Value3);
+      TheArray.Add(Value4);
+      TheArray.Add(Value5);
+      TheArray.Add(Value6);
+    END;
+    PROCEDURE ArrayToString@1000000019(ArrayIn@1000000000 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Array") : Text;
+    VAR
+      String@1000000002 : Text;
+      ArrayItem@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Object";
+      FirstItem@1000000003 : Boolean;
+    BEGIN
+      String := '';
+      FirstItem := TRUE;
+      FOREACH ArrayItem IN ArrayIn DO BEGIN
+        IF (FirstItem) THEN BEGIN
+          FirstItem := FALSE;
+        END ELSE BEGIN
+          String := String + ',';
+        END;
+        IF ( NOT (ISNULL(ArrayItem))) THEN BEGIN
+          String := String + ArrayItem.ToString();
+        END ELSE BEGIN
+          String := String + 'null';
+        END;
+      END;
+      EXIT(String);
+    END;
+    PROCEDURE ArrayListToString@1000000008(ArrayList@1000000000 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.ArrayList") : Text;
+    VAR
+      String@1000000002 : Text;
+      ArrayListItem@1000000001 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Object";
+      FirstItem@1000000003 : Boolean;
+    BEGIN
+      String := '';
+      FirstItem := TRUE;
+      FOREACH ArrayListItem IN ArrayList DO BEGIN
+        IF (FirstItem) THEN BEGIN
+          FirstItem := FALSE;
+        END ELSE BEGIN
+          String := String + ',';
+        END;
+        IF ( NOT (ISNULL(ArrayListItem))) THEN BEGIN
+          String := String + ArrayListItem.ToString();
+        END ELSE BEGIN
+          String := String + 'null';
+        END;
+      END;
+      EXIT(String);
+    END;
+
+    BEGIN
+    END.
+  }
+}
+


### PR DESCRIPTION
Extension of existing Regex with RegexOptions redesigned.
Plus matching test scripts.
Replacement for "Regex 2.0 wrapper" pull request which can be closed.