### PR TITLE
Added functions to fill value and property separately

### DIFF
--- a/BaseApp/COD1234.TXT
+++ b/BaseApp/COD1234.TXT
@@ -13,7 +13,8 @@ OBJECT Codeunit 1234 Json Text Reader/Writer
 
   }
   CODE
-  {    VAR
+  {
+    VAR
       StringBuilder@1000 : DotNet "'mscorlib'.System.Text.StringBuilder";
       StringWriter@1001 : DotNet "'mscorlib'.System.IO.StringWriter";
       JsonTextWriter@1004 : DotNet "'Newtonsoft.Json'.Newtonsoft.Json.JsonTextWriter";

--- a/BaseApp/COD1234.TXT
+++ b/BaseApp/COD1234.TXT
@@ -13,8 +13,7 @@ OBJECT Codeunit 1234 Json Text Reader/Writer
 
   }
   CODE
-  {
-    VAR
+  {    VAR
       StringBuilder@1000 : DotNet "'mscorlib'.System.Text.StringBuilder";
       StringWriter@1001 : DotNet "'mscorlib'.System.IO.StringWriter";
       JsonTextWriter@1004 : DotNet "'Newtonsoft.Json'.Newtonsoft.Json.JsonTextWriter";
@@ -164,13 +163,13 @@ OBJECT Codeunit 1234 Json Text Reader/Writer
     END;
 
     [External]
-    PROCEDURE WriteValue@1000000000(Variable@1000000000 : Variant);
+    PROCEDURE WriteValue@17(Variable@1000 : Variant);
     BEGIN
       JsonTextWriter.WriteValue(Variable);
     END;
 
     [External]
-    PROCEDURE WriteProperty@1000000001(VariableName@1000000000 : Text);
+    PROCEDURE WriteProperty@18(VariableName@1000 : Text);
     BEGIN
       JsonTextWriter.WritePropertyName(VariableName);
     END;

--- a/BaseApp/COD1234.TXT
+++ b/BaseApp/COD1234.TXT
@@ -163,6 +163,18 @@ OBJECT Codeunit 1234 Json Text Reader/Writer
       JSon := StringBuilder.ToString;
     END;
 
+    [External]
+    PROCEDURE WriteValue@1000000000(Variable@1000000000 : Variant);
+    BEGIN
+      JsonTextWriter.WriteValue(Variable);
+    END;
+
+    [External]
+    PROCEDURE WriteProperty@1000000001(VariableName@1000000000 : Text);
+    BEGIN
+      JsonTextWriter.WritePropertyName(VariableName);
+    END;
+
     BEGIN
     END.
   }


### PR DESCRIPTION
I think using the wrapper codeunit 1234 "Json Text Reader/Writer" should be as easy as using the base class from newtonsoft. But i was not able to do the following example in NAV because there was no function to add a value to an array.

```
StringBuilder sb = new StringBuilder();
StringWriter sw = new StringWriter(sb);

using (JsonWriter writer = new JsonTextWriter(sw))
{
    writer.Formatting = Formatting.Indented;

    writer.WriteStartObject();
    writer.WritePropertyName("CPU");
    writer.WriteValue("Intel");
    writer.WritePropertyName("PSU");
    writer.WriteValue("500W");
    writer.WritePropertyName("Drives");
    writer.WriteStartArray();
    writer.WriteValue("DVD read/writer");
    writer.WriteComment("(broken)");
    writer.WriteValue("500 gigabyte hard drive");
    writer.WriteValue("200 gigabyte hard drive");
    writer.WriteEnd();
    writer.WriteEndObject();
}

// {
//   "CPU": "Intel",
//   "PSU": "500W",
//   "Drives": [
//     "DVD read/writer"
//     /*(broken)*/,
//     "500 gigabyte hard drive",
//     "200 gigabyte hard drive"
//   ]
// }
```
Source:  https://www.newtonsoft.com/json/help/html/ReadingWritingJSON.htm 

To solve this i added two functions to fill value and property seperatly.