### PR TITLE
feat(soap): add ability to set SOAPAction Header

### DIFF
--- a/BaseApp/COD1290.TXT
+++ b/BaseApp/COD1290.TXT
@@ -38,6 +38,7 @@ OBJECT Codeunit 1290 SOAP Web Service Request Mgt.
       GlobalUsername@1008 : Text;
       GlobalBasicUsername@50000 : Text;
       GlobalBasicPassword@50001 : Text;
+      GlobalSoapAction@50015 : Text;
       TraceLogEnabled@1011 : Boolean;
       GlobalTimeout@1024 : Integer;
       InternalErr@1028 : TextConst 'ENU=The remote service has returned the following error message:\\';
@@ -61,6 +62,7 @@ OBJECT Codeunit 1290 SOAP Web Service Request Mgt.
       ResponseInStreamTempBlob.Blob.CREATEINSTREAM(ResponseInStream);
       CreateSoapRequest(HttpWebRequest.GetRequestStream,GlobalRequestBodyInStream,GlobalUsername,GlobalPassword);
       AddBasicAuthorizationHeader(GlobalURL, GlobalBasicUsername, GlobalBasicPassword, HttpWebRequest);
+      AddSoapActionHeader(GlobalSoapAction, HttpWebRequest);
       WebRequestHelper.GetWebResponse(HttpWebRequest,HttpWebResponse,ResponseInStream,
         HttpStatusCode,ResponseHeaders,GlobalProgressDialogEnabled);
       ExtractContentFromResponse(ResponseInStream,ResponseBodyTempBlob);
@@ -231,6 +233,12 @@ OBJECT Codeunit 1290 SOAP Web Service Request Mgt.
     END;
 
     [External]
+    PROCEDURE SetAction(SoapAction@50014 : Text);
+    BEGIN
+      GlobalSoapAction = SoapAction;
+    END;
+
+    [External]
     PROCEDURE SetTimeout@7(NewTimeout@1000 : Integer);
     BEGIN
       GlobalTimeout := NewTimeout;
@@ -285,6 +293,15 @@ OBJECT Codeunit 1290 SOAP Web Service Request Mgt.
       DotNet_CredentialCache.Add(DotNet_Uri, 'Basic', DotNet_NetworkCredential);
 
       DotNet_HttpWebRequest.Credentials := DotNet_CredentialCache;
+    END;
+
+    LOCAL PROCEDURE AddSoapActionHeader(SoapAction@50012 : Text;VAR DotNet_HttpWebRequest@50013 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Net.HttpWebRequest");
+    VAR
+    BEGIN
+      IF (SoapAction = '') THEN
+        EXIT;
+      
+      DotNet_HttpWebRequest.Headers.Add('SOAPAction', SoapAction);
     END;
 
     [External]

--- a/BaseApp/COD1290.TXT
+++ b/BaseApp/COD1290.TXT
@@ -235,7 +235,7 @@ OBJECT Codeunit 1290 SOAP Web Service Request Mgt.
     [External]
     PROCEDURE SetAction(SoapAction@50014 : Text);
     BEGIN
-      GlobalSoapAction = SoapAction;
+      GlobalSoapAction := SoapAction;
     END;
 
     [External]


### PR DESCRIPTION
According to SOAP 1.1 specification

https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383528

a WebService can apply routing based on `SOAPAction` HTTP Header and therefore, may be required to send a request.

Here is an usage sample :

```
// open a pipe from the buffer which will be used by the SOAP Request
tRec_TempBlob.Blob.CREATEINSTREAM(lInStr);

// init the SOAP Request
CLEAR(lCu_SOAPWebServiceRequestMgt);
lCu_SOAPWebServiceRequestMgt.SetGlobals(lInStr, lTxt_NotMvtMatSOAUri, '', '');
lCu_SOAPWebServiceRequestMgt.SetBasicCredentials(lTxt_SOAUsername, lTxt_SOAPassword);
lCu_SOAPWebServiceRequestMgt.SetAction('Company/PullAgencies');
lCu_SOAPWebServiceRequestMgt.DisableHttpsCheck();
lCu_SOAPWebServiceRequestMgt.DisableProgressDialog();
lCu_SOAPWebServiceRequestMgt.SetTraceMode(TRUE);
lCu_SOAPWebServiceRequestMgt.SetContentType('text/xml;charset=utf-8');

// send the SOAP Request
IF NOT (lCu_SOAPWebServiceRequestMgt.SendRequestToWebService()) THEN
  lCu_SOAPWebServiceRequestMgt.ProcessFaultResponse('');

// process information received from the request
lXml_WSPullAgencies.SETSOURCE(lInStr);
lCu_SOAPWebServiceRequestMgt.GetResponseContent(lInStr);
```