### PR TITLE
feat(soap): add ability to set text-encoding

### DIFF
--- a/BaseApp/COD1290.TXT
+++ b/BaseApp/COD1290.TXT
@@ -39,6 +39,7 @@ OBJECT Codeunit 1290 SOAP Web Service Request Mgt.
       GlobalBasicUsername@50000 : Text;
       GlobalBasicPassword@50001 : Text;
       GlobalSoapAction@50015 : Text;
+      GlobalStreamEncoding@50016 : TextEncoding;
       TraceLogEnabled@1011 : Boolean;
       GlobalTimeout@1024 : Integer;
       InternalErr@1028 : TextConst 'ENU=The remote service has returned the following error message:\\';
@@ -59,7 +60,7 @@ OBJECT Codeunit 1290 SOAP Web Service Request Mgt.
       CheckGlobals;
       BuildWebRequest(GlobalURL,HttpWebRequest);
       ResponseInStreamTempBlob.INIT;
-      ResponseInStreamTempBlob.Blob.CREATEINSTREAM(ResponseInStream);
+      ResponseInStreamTempBlob.Blob.CREATEINSTREAM(ResponseInStream, GlobalStreamEncoding);
       CreateSoapRequest(HttpWebRequest.GetRequestStream,GlobalRequestBodyInStream,GlobalUsername,GlobalPassword);
       AddBasicAuthorizationHeader(GlobalURL, GlobalBasicUsername, GlobalBasicPassword, HttpWebRequest);
       AddSoapActionHeader(GlobalSoapAction, HttpWebRequest);
@@ -167,14 +168,14 @@ OBJECT Codeunit 1290 SOAP Web Service Request Mgt.
       ResponseBodyXMLDoc := ResponseBodyXMLDoc.XmlDocument;
       ResponseBodyXMLDoc.AppendChild(ResponseBodyXMLDoc.ImportNode(ResponseBodyXmlNode.FirstChild,TRUE));
 
-      BodyTempBlob.Blob.CREATEOUTSTREAM(BodyOutStream);
+      BodyTempBlob.Blob.CREATEOUTSTREAM(BodyOutStream, GlobalStreamEncoding);
       ResponseBodyXMLDoc.Save(BodyOutStream);
       TraceLogXmlDocToTempFile(ResponseBodyXMLDoc,'ResponseBodyContent');
     END;
 
     PROCEDURE GetResponseContent@22(VAR ResponseBodyInStream@1000 : InStream);
     BEGIN
-      ResponseBodyTempBlob.Blob.CREATEINSTREAM(ResponseBodyInStream);
+      ResponseBodyTempBlob.Blob.CREATEINSTREAM(ResponseBodyInStream, GlobalStreamEncoding);
     END;
 
     PROCEDURE ProcessFaultResponse@15(SupportInfo@1001 : Text);
@@ -220,6 +221,8 @@ OBJECT Codeunit 1290 SOAP Web Service Request Mgt.
       GlobalUsername := Username;
       GlobalPassword := Password;
 
+      GlobalStreamEncoding := TEXTENCODING::Windows;
+
       GlobalProgressDialogEnabled := TRUE;
 
       TraceLogEnabled := FALSE;
@@ -236,6 +239,12 @@ OBJECT Codeunit 1290 SOAP Web Service Request Mgt.
     PROCEDURE SetAction(SoapAction@50014 : Text);
     BEGIN
       GlobalSoapAction := SoapAction;
+    END;
+
+    [External]
+    PROCEDURE SetStreamEncoding(StreamEncoding@50017 : TextEncoding);
+    BEGIN
+      GlobalStreamEncoding := StreamEncoding;
     END;
 
     [External]


### PR DESCRIPTION
Some platforms are providing UTF-8 encoding endpoints which could be usefull/required in some context - especially for European Countries (like France or Germany) who are using special characters (ie: in employee name).

This change is allowing to set a specific encoding during the exchange operation with target service.
By default, it's set to Windows encoding from `SetGlobals`.
You can then change it to UTF-8 (or any other supported encoding) using `SetStreamEncoding`

Here is a quick sample :

```
// init the SOAP Request
CLEAR(lCu_SOAPWebServiceRequestMgt);
lCu_SOAPWebServiceRequestMgt.SetGlobals(lInStr, lTxt_AgentsSOAUri, '', '');
lCu_SOAPWebServiceRequestMgt.SetStreamEncoding(TEXTENCODING::UTF8);
lCu_SOAPWebServiceRequestMgt.SetContentType('text/xml;charset=utf-8');

// send the SOAP Request
IF NOT (lCu_SOAPWebServiceRequestMgt.SendRequestToWebService()) THEN
  lCu_SOAPWebServiceRequestMgt.ProcessFaultResponse('');

// load the received XML structure
CLEAR(lInStr);
lCu_SOAPWebServiceRequestMgt.GetResponseContent(lInStr);
```