### PR TITLE
Add logging and SSL client certificate authentication

### DIFF
--- a/BaseApp/COD1297.TXT
+++ b/BaseApp/COD1297.TXT
@@ -29,9 +29,15 @@ OBJECT Codeunit 1297 Http Web Request Mgt.
     VAR
       WebRequestHelper@1001 : Codeunit 1299;
       HttpWebResponse@1006 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Net.HttpWebResponse";
+      TempReturnTempBlob@1000000000 : TEMPORARY Record 99008535;
     BEGIN
-      EXIT(WebRequestHelper.GetWebResponse(HttpWebRequest,HttpWebResponse,ResponseInStream,HttpStatusCode,
-          ResponseHeaders,GlobalProgressDialogEnabled));
+      IF (WebRequestHelper.GetWebResponse(HttpWebRequest,HttpWebResponse,ResponseInStream,HttpStatusCode,
+          ResponseHeaders,GlobalProgressDialogEnabled)) THEN BEGIN
+          TraceLogStreamToTempFile(ResponseInStream, 'ResponseBodyContent', TempReturnTempBlob);
+        EXIT(TRUE);
+      END;
+
+      EXIT(FALSE);
     END;
 
     PROCEDURE GetResponseStream@23(VAR ResponseInStream@1005 : InStream) : Boolean;
@@ -40,9 +46,15 @@ OBJECT Codeunit 1297 Http Web Request Mgt.
       HttpWebResponse@1006 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Net.HttpWebResponse";
       HttpStatusCode@1002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Net.HttpStatusCode";
       ResponseHeaders@1000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.Specialized.NameValueCollection";
+      TempReturnTempBlob@1000000000 : TEMPORARY Record 99008535;
     BEGIN
-      EXIT(WebRequestHelper.GetWebResponse(HttpWebRequest,HttpWebResponse,ResponseInStream,HttpStatusCode,
-          ResponseHeaders,GlobalProgressDialogEnabled));
+      IF (WebRequestHelper.GetWebResponse(HttpWebRequest, HttpWebResponse, ResponseInStream, HttpStatusCode,
+          ResponseHeaders, GlobalProgressDialogEnabled)) THEN BEGIN
+        TraceLogStreamToTempFile(ResponseInStream, 'ResponseBodyContent', TempReturnTempBlob);
+        EXIT(TRUE);
+      END;
+
+      EXIT(FALSE);
     END;
 
     [TryFunction]
@@ -196,6 +208,10 @@ OBJECT Codeunit 1297 Http Web Request Mgt.
     VAR
       RequestStr@1004 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.IO.Stream";
       StreamWriter@1003 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.IO.StreamWriter";
+      TempBlob@1000000000 : TEMPORARY Record 99008535;
+      ReturnTempBlob@1000000003 : TEMPORARY Record 99008535;
+      InStr@1000000001 : InStream;
+      TxtEncoding@1000000002 : TextEncoding;
     BEGIN
       RequestStr := HttpWebRequest.GetRequestStream;
       StreamWriter := StreamWriter.StreamWriter(RequestStr,Encoding);
@@ -203,6 +219,14 @@ OBJECT Codeunit 1297 Http Web Request Mgt.
       StreamWriter.Flush;
       StreamWriter.Close;
       StreamWriter.Dispose;
+
+      TxtEncoding := TEXTENCODING::UTF8;
+      IF (FORMAT(Encoding) = FORMAT(Encoding.ASCII)) THEN
+        TxtEncoding := TEXTENCODING::Windows;
+      
+      TempBlob.WriteAsText(BodyText, TxtEncoding);
+      TempBlob.Blob.CREATEINSTREAM(InStr, TxtEncoding);
+      TraceLogStreamToTempFile(InStr, 'RequestBodyContent', ReturnTempBlob);
     END;
 
     PROCEDURE SetTimeout@7(NewTimeout@1000 : Integer);
@@ -285,6 +309,11 @@ OBJECT Codeunit 1297 Http Web Request Mgt.
       FileManagement@1001 : Codeunit 419;
       FileStream@1003 : DotNet "'mscorlib'.System.IO.FileStream";
       FileMode@1004 : DotNet "'mscorlib'.System.IO.FileMode";
+      SeekOrigin@1000000003 : DotNet "'mscorlib'.System.IO.SeekOrigin";
+      TempBlob@1000000000 : TEMPORARY Record 99008535;
+      ReturnTempBlob@1000000004 : TEMPORARY Record 99008535;
+      OutStr@1000000001 : OutStream;
+      InStr@1000000002 : InStream;
     BEGIN
       IF BodyFilePath = '' THEN
         EXIT;
@@ -293,12 +322,19 @@ OBJECT Codeunit 1297 Http Web Request Mgt.
 
       FileStream := FileStream.FileStream(BodyFilePath,FileMode.Open);
       FileStream.CopyTo(HttpWebRequest.GetRequestStream);
+
+      TempBlob.Blob.CREATEOUTSTREAM(OutStr);
+      FileStream.Seek(0, SeekOrigin."Begin");
+      FileStream.CopyTo(OutStr);
+      TempBlob.Blob.CREATEINSTREAM(InStr);
+      TraceLogStreamToTempFile(InStr, 'RequestBodyContent', ReturnTempBlob);
     END;
 
     PROCEDURE AddBodyBlob@19(VAR TempBlob@1000 : Record 99008535);
     VAR
       RequestStr@1002 : DotNet "'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.IO.Stream";
       BlobStr@1001 : InStream;
+      ReturnTempBlob@1000000000 : TEMPORARY Record 99008535;
     BEGIN
       IF NOT TempBlob.Blob.HASVALUE THEN
         EXIT;
@@ -309,6 +345,8 @@ OBJECT Codeunit 1297 Http Web Request Mgt.
       RequestStr.Flush;
       RequestStr.Close;
       RequestStr.Dispose;
+
+      TraceLogStreamToTempFile(BlobStr, 'RequestBodyContent', ReturnTempBlob);
     END;
 
     [External]

--- a/BaseApp/COD1297.TXT
+++ b/BaseApp/COD1297.TXT
@@ -23,6 +23,7 @@ OBJECT Codeunit 1297 Http Web Request Mgt.
       GlobalProgressDialogEnabled@1023 : Boolean;
       InternalErr@1001 : TextConst 'ENU=The remote service has returned the following error message:\\';
       NoCookieForYouErr@1040 : TextConst 'ENU=The web request has no cookies.';
+      ErrClientCertNotFound@1000000000 : TextConst 'ENU=Unable to retrieve requested Certificate using thumbprint %1. Please ensure it is stored in Personal Repository from either Service User or NAV Server.';
 
     PROCEDURE GetResponse@6(VAR ResponseInStream@1005 : InStream;VAR HttpStatusCode@1000 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Net.HttpStatusCode";VAR ResponseHeaders@1003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Collections.Specialized.NameValueCollection") : Boolean;
     VAR
@@ -360,6 +361,48 @@ OBJECT Codeunit 1297 Http Web Request Mgt.
     PROCEDURE OnOverrideUrl@36(VAR Url@1000 : Text);
     BEGIN
       // Provides an option to rewrite URL in non SaaS environments.
+    END;
+
+    PROCEDURE AddClientCertificate@1000000000(ClientCertThumbprint@1000000000 : Text);
+    VAR
+      X509Store@1000000001 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Security.Cryptography.X509Certificates.X509Store";
+      OpenFlags@1000000002 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Security.Cryptography.X509Certificates.OpenFlags";
+      StoreName@1000000004 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Security.Cryptography.X509Certificates.StoreName";
+      StoreLocation@1000000005 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Security.Cryptography.X509Certificates.StoreLocation";
+      X509FindType@1000000006 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Security.Cryptography.X509Certificates.X509FindType";
+      X509Certificate2Collection@1000000003 : DotNet "'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'.System.Security.Cryptography.X509Certificates.X509Certificate2Collection";
+    BEGIN
+      // ask for certicate Computer/Personal store
+      X509Store := X509Store.X509Store(StoreName.My, StoreLocation.LocalMachine);
+      
+      // open with read-only mode
+      X509Store.Open(OpenFlags.ReadOnly);
+      
+      // search for requested certificate
+      X509Certificate2Collection := X509Store.Certificates.Find(X509FindType.FindByThumbprint, ClientCertThumbprint, TRUE);
+      
+      // in case requested certificate cannot be found, attempt to retrieve it from Service User
+      IF (X509Certificate2Collection.Count < 1) THEN BEGIN
+        
+        // close opened store
+        X509Store.Close();
+        
+        // init Current User/Personal store
+        X509Store := X509Store.X509Store(StoreName.My, StoreLocation.CurrentUser);
+        
+        // open the store in read-only mode
+        X509Store.Open(OpenFlags.ReadOnly);
+        
+        // collect certificates matching the requested one
+        X509Certificate2Collection := X509Store.Certificates.Find(X509FindType.FindByThumbprint, ClientCertThumbprint, TRUE);
+        
+        // if we're still not able to retrieve the certificate - throw exception
+        IF (X509Certificate2Collection.Count < 1) THEN
+          ERROR(ErrClientCertNotFound, ClientCertThumbprint);
+      END;
+
+      // attach client certificate to HTTP Web Request
+      HttpWebRequest.ClientCertificates := X509Certificate2Collection;
     END;
 
     BEGIN


### PR DESCRIPTION
This pull request improve standard codeunit `Http Web Request Mgt.` use to send HTTP Request (ie: to REST Api).

It extend initial tracing to both normal response and body appendal, like it's done into `SOAP Web Service Request Mgt.` alternative codeunit.

Also, it provides an extra method called `AddClientCertificate()` in order to use SSL Client Authentication (some place base their auth on it - Amazon EDI, Chorus Pro, etc...)

`AddBody()` function got a new DotNet variable in order to reset stream reader position
 - [SeekOrigin](https://docs.microsoft.com/fr-fr/dotnet/api/system.io.seekorigin?view=netframework-4.8)

`AddClientCertificate()` contains DotNet variables which will be used to open either computer certificate handler or service certificate handler. It is OnPrem oriented. (I have no clue how it can be handled on SaaS :( )
 - [X509Store](https://docs.microsoft.com/fr-fr/dotnet/api/system.security.cryptography.x509certificates.x509store?view=netframework-4.8)
 - [OpenFlags](https://docs.microsoft.com/fr-fr/dotnet/api/system.security.cryptography.x509certificates.openflags?view=netframework-4.8)
 - [StoreName](https://docs.microsoft.com/fr-fr/dotnet/api/system.security.cryptography.x509certificates.storename?view=netframework-4.8)
 - [StoreLocation](https://docs.microsoft.com/fr-fr/dotnet/api/system.security.cryptography.x509certificates.storelocation?view=netframework-4.8)
 - [X509FindType](https://docs.microsoft.com/fr-fr/dotnet/api/system.security.cryptography.x509certificates.x509findtype?view=netframework-4.8)
 - [X509Certificate2Collection](https://docs.microsoft.com/fr-fr/dotnet/api/system.security.cryptography.x509certificates.x509certificate2collection?view=netframework-4.8)

Usage sample :

```
lCu_HttpWebRequestMgt.Initialize('https://localhost:8080/directfulfillment/v1/orders/shipment');
lCu_HttpWebRequestMgt.SetMethod('POST');
lCu_HttpWebRequestMgt.AddClientCertificate('client_certificate_thumbprint');
lCu_HttpWebRequestMgt.SetTraceLogEnabled(TRUE);

tRec_TemBlob.Blob.CREATEINSTREAM(lInStr);
IF NOT (lCu_HttpWebRequestMgt.GetResponseStream(lInStr)) THEN
  lCu_HttpWebRequestMgt.ProcessFaultResponse('');

MESSAGE('%1', tRec_TempBlob.ReadTextLine());
```